### PR TITLE
Service update job

### DIFF
--- a/app/facades/service_update_facade.rb
+++ b/app/facades/service_update_facade.rb
@@ -3,24 +3,13 @@ class ServiceUpdateFacade
     id = service_watchmode_id(service_name)
     service = Service.find_by(watchmode_id: id)
 
+    movie_pages = WatchmodeService.get_movies_by_service(id)
+
+    # ADD CONDITIONAL HERE - IF WATCHMODE API CALL SUCCESSFUL, DO THINGS, ELSE ERROR
     # MovieAvailabilities must be destroyed/recreated with each refresh
     # due to Watchmode API endpoint limitations & rate limits
-    MovieAvailability.where(service: service).destroy_all
+    ServiceUpdateJob.perform_later(service, movie_pages)
 
-    movie_pages = WatchmodeService.get_movies_by_service(id)
-    movie_pages.each do |movie_page|
-      movie_page[:titles].each do |movie_data|
-        movie = Movie.find_by(tmdb_id: movie_data[:tmdb_id])
-        unless movie
-          movie = Movie.create(
-            title: movie_data[:title],
-            tmdb_id: movie_data[:tmdb_id],
-            year: movie_data[:year]
-          )
-        end
-        movie.movie_availabilities.create(service: service)
-      end
-    end
     ServiceRefresh.new(service[:name], movie_pages[0][:total_results])
   end
 

--- a/app/jobs/service_update_job.rb
+++ b/app/jobs/service_update_job.rb
@@ -1,0 +1,21 @@
+class ServiceUpdateJob < ApplicationJob
+  queue_as :default
+
+  def perform(service, movie_pages)
+    MovieAvailability.where(service: service).destroy_all
+
+    movie_pages.each do |movie_page|
+      movie_page[:titles].each do |movie_data|
+        movie = Movie.find_by(tmdb_id: movie_data[:tmdb_id])
+        unless movie
+          movie = Movie.create(
+            title: movie_data[:title],
+            tmdb_id: movie_data[:tmdb_id],
+            year: movie_data[:year]
+          )
+        end
+        movie.movie_availabilities.create(service: service)
+      end
+    end
+  end
+end

--- a/spec/fixtures/movie_pages.json
+++ b/spec/fixtures/movie_pages.json
@@ -1,0 +1,107 @@
+[
+  {
+    "titles":
+      [
+        {
+          "id":160037,
+          "title":"Breathless",
+          "year":1983,
+          "imdb_id":"tt0085276",
+          "tmdb_id":1058,
+          "tmdb_type":"movie",
+          "type":"movie"
+        },
+        {
+          "id":1247225,
+          "title":"Spy Cat",
+          "year":2018,
+          "imdb_id":"tt5746054",
+          "tmdb_id":509733,
+          "tmdb_type":"movie",
+          "type":"movie"
+        },
+        {
+          "id":1410097,
+          "title":"The Oath",
+          "year":2018,
+          "imdb_id":"tt7461200",
+          "tmdb_id":520596,
+          "tmdb_type":"movie",
+          "type":"movie"
+        },
+        {
+          "id":199348,
+          "title":"Desierto",
+          "year":2015,
+          "imdb_id":"tt3147312",
+          "tmdb_id":258363,
+          "tmdb_type":"movie",
+          "type":"movie"
+        },
+        {
+          "id":1415812,
+          "title":"The Rewrite",
+          "year":2014,
+          "imdb_id":"tt2509850",
+          "tmdb_id":289727,
+          "tmdb_type":"movie",
+          "type":"movie"
+        }
+      ],
+    "page":1,
+    "total_results":10,
+    "total_pages":2},
+  {
+    "titles":
+      [
+        {
+          "id":1516103,
+          "title":"The Secret Garden",
+          "year":2020,
+          "imdb_id":"tt2702920",
+          "tmdb_id":521034,
+          "tmdb_type":"movie",
+          "type":"movie"
+        },
+        {
+          "id":1590645,
+          "title":"The Cave",
+          "year":2019,
+          "imdb_id":"tt7178226",
+          "tmdb_id":621729,
+          "tmdb_type":"movie",
+          "type":"movie"
+        },
+        {
+          "id":1101923,
+          "title":"Did You Hear About the Morgans?",
+          "year":2009,
+          "imdb_id":"tt1314228",
+          "tmdb_id":24438,
+          "tmdb_type":"movie",
+          "type":"movie"
+        },
+        {
+          "id":1398258,
+          "title":"The Hurricane Heist",
+          "year":2018,
+          "imdb_id":"tt5360952",
+          "tmdb_id":430040,
+          "tmdb_type":"movie",
+          "type":"movie"
+        },
+        {
+          "id":139277,
+          "title":"BPM (Beats per Minute)",
+          "year":2017,
+          "imdb_id":"tt6135348",
+          "tmdb_id":451945,
+          "tmdb_type":"movie",
+          "type":"movie"
+        }
+      ],
+    "page":2,
+    "total_results":10,
+    "total_pages":2
+  }
+]

--- a/spec/jobs/service_update_job_spec.rb
+++ b/spec/jobs/service_update_job_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe ServiceUpdateJob, type: :job do
+  it 'creates movies and movie availabilities' do
+    hulu = Service.create(
+      name: 'Hulu',
+      watchmode_id: 157,
+      logo: 'hulu_logo.png'
+    )
+
+    expect(Movie.all).to eq([])
+    expect(MovieAvailability.all).to eq([])
+
+    json = File.read('spec/fixtures/movie_pages.json')
+    movie_pages = JSON.parse(json, symbolize_names:true)
+
+    ServiceUpdateJob.perform_now(hulu, movie_pages)
+
+    movies = Movie.all
+    availabilities = MovieAvailability.all
+
+    expect(movies.length).to eq(10)
+    expect(availabilities.length).to eq(10)
+
+    movies.each do |movie|
+      expect(movie).to be_a(Movie)
+      expect(movie.services).to eq([hulu])
+    end
+
+    availabilities.each do |availability|
+      expect(availability).to be_a(MovieAvailability)
+      expect(availability.service).to eq(hulu)
+    end
+  end
+
+  it 'does not create duplicate movies or availabilities when they already exist' do
+    hulu = Service.create(
+      name: 'Hulu',
+      watchmode_id: 157,
+      logo: 'hulu_logo.png'
+    )
+    spy_cat = Movie.create(
+      title: 'Spy Cat',
+      tmdb_id: 509733
+    )
+    spy_cat_on_hulu = hulu.movie_availabilities.create(
+      movie: spy_cat
+    )
+
+    expect(Movie.all).to eq([spy_cat])
+    expect(MovieAvailability.all).to eq([spy_cat_on_hulu])
+
+    json = File.read('spec/fixtures/movie_pages.json')
+    movie_pages = JSON.parse(json, symbolize_names:true)
+
+    ServiceUpdateJob.perform_now(hulu, movie_pages)
+
+    movies = Movie.all
+    availabilities = MovieAvailability.all
+
+    expect(movies.length).to eq(10)
+    expect(availabilities.length).to eq(10)
+
+    expect(Movie.find_by(id:spy_cat.id)).to eq(spy_cat)
+    expect(MovieAvailability.find_by(movie:spy_cat)).not_to eq(spy_cat)
+    expect(MovieAvailability.where(movie:spy_cat).length).to eq(1)
+  end
+end


### PR DESCRIPTION
This PR will:
* Create an active job to handle movie/availability creation in GET '/update_availability' endpoint with background workers (this endpoint was previously very slow due to the volume of movies/availabilities created)
* Move movie/availability creation into new active job
* Add tests/fixture file for new active job
