### PR TITLE
Movies populate details

### DIFF
--- a/app/controllers/api/v1/movies_controller.rb
+++ b/app/controllers/api/v1/movies_controller.rb
@@ -22,6 +22,24 @@ class Api::V1::MoviesController < ApplicationController
     Movie.destroy(params[:id])
   end
 
+  def populate_details
+    movies = Movie.where(description:nil)
+    unless movies == []
+      TmdbFacade.populate_movie_details(movies)
+      output = {
+        movies_updated: movies.length,
+        update_status: 'In progress - it may take several minutes for the database to be fully updated.'
+      }
+      render json: output
+    else
+      output = {
+        movies_updated: 0,
+        update_status: 'Complete - all movies are populated.'
+      }
+      render json: output
+    end
+  end
+
   private
 
     def movie_params

--- a/app/controllers/api/v1/movies_controller.rb
+++ b/app/controllers/api/v1/movies_controller.rb
@@ -24,17 +24,24 @@ class Api::V1::MoviesController < ApplicationController
 
   def populate_details
     movies = Movie.where(description:nil)
-    unless movies == []
-      TmdbFacade.populate_movie_details(movies)
-      output = {
-        movies_updated: movies.length,
-        update_status: 'In progress - it may take several minutes for the database to be fully updated.'
-      }
-      render json: output
-    else
+    if movies == []
       output = {
         movies_updated: 0,
         update_status: 'Complete - all movies are populated.'
+      }
+      render json: output
+    elsif movies.length < 10
+      TmdbFacade.populate_movie_details(movies)
+      output = {
+        movies_updated: movies.length,
+        update_status: 'Complete - incomplete movies have been populated.'
+      }
+      render json: output
+    else
+      MovieDetailsUpdateJob.perform_later(movies)
+      output = {
+        movies_updated: movies.length,
+        update_status: 'In progress - it may take several minutes for the database to be fully updated.'
       }
       render json: output
     end

--- a/app/controllers/api/v1/movies_controller.rb
+++ b/app/controllers/api/v1/movies_controller.rb
@@ -43,6 +43,6 @@ class Api::V1::MoviesController < ApplicationController
   private
 
     def movie_params
-      params.permit(:title, :tmdb_id, :poster_path, :description, :genres, :vote_average, :vote_count, :year)
+      params.permit(:title, :tmdb_id, :poster_path, :description, :vote_average, :vote_count, :year)
     end
 end

--- a/app/facades/tmdb_facade.rb
+++ b/app/facades/tmdb_facade.rb
@@ -1,0 +1,19 @@
+class TmdbFacade
+  def self.populate_movie_details(movies)
+    movies.each do |movie|
+      movie_data = TmdbService.get_movie_info(movie)
+      movie_info = MovieInfo.new(movie_data)
+      movie.update(
+        poster_path: movie_info.poster_path,
+        description: movie_info.description,
+        vote_average: movie_info.vote_average,
+        vote_count: movie_info.vote_count,
+        year: movie_info.year
+      )
+      movie_info.genres.each do |genre|
+        current_genre = Genre.create_with(name:genre[:name]).find_or_create_by(tmdb_id:genre[:id])
+        current_genre.movie_genres.create(movie:movie)
+      end
+    end
+  end
+end

--- a/app/jobs/movie_details_update_job.rb
+++ b/app/jobs/movie_details_update_job.rb
@@ -1,0 +1,21 @@
+class MovieDetailsUpdateJob < ApplicationJob
+  queue_as :default
+
+  def perform(movies)
+    movies.each do |movie|
+      movie_data = TmdbService.get_movie_info(movie)
+      movie_info = MovieInfo.new(movie_data)
+      movie.update(
+        poster_path: movie_info.poster_path,
+        description: movie_info.description,
+        vote_average: movie_info.vote_average,
+        vote_count: movie_info.vote_count,
+        year: movie_info.year
+      )
+      movie_info.genres.each do |genre|
+        current_genre = Genre.create_with(name:genre[:name]).find_or_create_by(tmdb_id:genre[:id])
+        current_genre.movie_genres.create(movie:movie)
+      end
+    end
+  end
+end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,0 +1,6 @@
+class Genre < ApplicationRecord
+  validates_presence_of :name
+
+  has_many :movie_genres
+  has_many :movies, through: :movie_genres
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -3,4 +3,6 @@ class Movie < ApplicationRecord
 
   has_many :movie_availabilities
   has_many :services, through: :movie_availabilities
+  has_many :movie_genres
+  has_many :genres, through: :movie_genres
 end

--- a/app/models/movie_genre.rb
+++ b/app/models/movie_genre.rb
@@ -1,0 +1,4 @@
+class MovieGenre < ApplicationRecord
+  belongs_to :movie
+  belongs_to :genre
+end

--- a/app/poros/movie_info.rb
+++ b/app/poros/movie_info.rb
@@ -1,0 +1,17 @@
+class MovieInfo
+  attr_reader :poster_path,
+              :description,
+              :vote_average,
+              :vote_count,
+              :year,
+              :genres
+
+  def initialize(movie_data)
+    @poster_path = movie_data[:poster_path]
+    @description = movie_data[:overview]
+    @vote_average = movie_data[:vote_average]
+    @vote_count = movie_data[:vote_count]
+    @year = movie_data[:release_date].first(4)
+    @genres = movie_data[:genres]
+  end
+end

--- a/app/services/tmdb_service.rb
+++ b/app/services/tmdb_service.rb
@@ -1,0 +1,14 @@
+class TmdbService
+  def self.get_movie_info(movie)
+    response = conn.get("/3/movie/#{movie.tmdb_id}")
+    JSON.parse(response.body, symbolize_names:true)
+  end
+
+  private
+
+    def self.conn
+      Faraday.new(url: 'https://api.themoviedb.org') do |req|
+        req.params['api_key'] = ENV['TMDB_API_KEY']
+      end
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       get '/services/update_availability', to: 'services#update_availability'
       get '/services/update_all_availabilities', to: 'services#update_all_availabilities'
       resources :services
+      get '/movies/populate_details', to: 'movies#populate_details'
       resources :movies
     end
   end

--- a/db/migrate/20210416193749_remove_genres_from_movies.rb
+++ b/db/migrate/20210416193749_remove_genres_from_movies.rb
@@ -1,0 +1,5 @@
+class RemoveGenresFromMovies < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :movies, :genres, :string
+  end
+end

--- a/db/migrate/20210416193941_create_genres.rb
+++ b/db/migrate/20210416193941_create_genres.rb
@@ -1,0 +1,9 @@
+class CreateGenres < ActiveRecord::Migration[6.1]
+  def change
+    create_table :genres do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210416194034_create_movie_genres.rb
+++ b/db/migrate/20210416194034_create_movie_genres.rb
@@ -1,0 +1,10 @@
+class CreateMovieGenres < ActiveRecord::Migration[6.1]
+  def change
+    create_table :movie_genres do |t|
+      t.references :movie, null: false, foreign_key: true
+      t.references :genre, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210416205955_add_tmdb_id_to_genres.rb
+++ b/db/migrate/20210416205955_add_tmdb_id_to_genres.rb
@@ -1,0 +1,5 @@
+class AddTmdbIdToGenres < ActiveRecord::Migration[6.1]
+  def change
+    add_column :genres, :tmdb_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_11_173743) do
+ActiveRecord::Schema.define(version: 2021_04_16_194034) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "genres", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "movie_availabilities", force: :cascade do |t|
     t.bigint "movie_id", null: false
@@ -24,12 +30,20 @@ ActiveRecord::Schema.define(version: 2021_04_11_173743) do
     t.index ["service_id"], name: "index_movie_availabilities_on_service_id"
   end
 
+  create_table "movie_genres", force: :cascade do |t|
+    t.bigint "movie_id", null: false
+    t.bigint "genre_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["genre_id"], name: "index_movie_genres_on_genre_id"
+    t.index ["movie_id"], name: "index_movie_genres_on_movie_id"
+  end
+
   create_table "movies", force: :cascade do |t|
     t.string "title"
     t.integer "tmdb_id"
     t.string "poster_path"
     t.string "description"
-    t.string "genres"
     t.float "vote_average"
     t.integer "vote_count"
     t.string "year"
@@ -47,4 +61,6 @@ ActiveRecord::Schema.define(version: 2021_04_11_173743) do
 
   add_foreign_key "movie_availabilities", "movies"
   add_foreign_key "movie_availabilities", "services"
+  add_foreign_key "movie_genres", "genres"
+  add_foreign_key "movie_genres", "movies"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_16_194034) do
+ActiveRecord::Schema.define(version: 2021_04_16_205955) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 2021_04_16_194034) do
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "tmdb_id"
   end
 
   create_table "movie_availabilities", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,12 +14,12 @@ netflix = Service.create(
 
 amazon_prime = Service.create(
   name: 'Amazon Prime Video',
-  watchmode_id: 157,
-  logo: 'prime_video_logo.jpeg'  
+  watchmode_id: 26,
+  logo: 'prime_video_logo.jpeg'
 )
 
 hulu = Service.create(
   name: 'Hulu',
-  watchmode_id: 26,
+  watchmode_id: 157,
   logo: 'hulu_logo.jpeg'
 )

--- a/spec/factories/movie.rb
+++ b/spec/factories/movie.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     tmdb_id { Faker::Number.within(range: 1..100000) }
     poster_path { Faker::LoremFlickr.image }
     description { Faker::Movie.quote }
-    genres { Faker::Book.genre }
     vote_average { Faker::Number.decimal(l_digits: 2, r_digits: 2) }
     vote_count { Faker::Number.within(range: 1..10000) }
     year { Faker::Number.within(range: 1920..2021) }

--- a/spec/fixtures/vcr_cassettes/MovieDetailsUpdateJob/populates_details_for_incomplete_movies.yml
+++ b/spec/fixtures/vcr_cassettes/MovieDetailsUpdateJob/populates_details_for_incomplete_movies.yml
@@ -1,0 +1,212 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.themoviedb.org/3/movie/816?api_key=<TMDB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.3.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 16 Apr 2021 20:43:27 GMT
+      Server:
+      - openresty
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, PUT, DELETE, OPTIONS
+      Access-Control-Expose-Headers:
+      - ETag, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After,
+        Content-Length, Content-Range
+      Cache-Control:
+      - public, max-age=21600
+      X-Memc:
+      - HIT
+      X-Memc-Key:
+      - d485a21da9c0e054971e82e13703bebab13cca1f
+      X-Memc-Age:
+      - '13358'
+      X-Memc-Expires:
+      - '8242'
+      Etag:
+      - W/"50d526eaa1cf34d9ce498fac9f6208f7"
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - Hit from cloudfront
+      Via:
+      - 1.1 264cccdb967e804907074b11d3a83242.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - DEN50-C2
+      X-Amz-Cf-Id:
+      - GLW-H9nzaqDdy_HUff3ZrXkWfxLl5dcS7KmfQgd8CaJ3xCwKyihHcA==
+      Age:
+      - '14364'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"adult":false,"backdrop_path":"/tsxwVsl9BYxy9y1AtxpM7xpNiC8.jpg","belongs_to_collection":{"id":1006,"name":"Austin
+        Powers Collection","poster_path":"/1PkGnyFwRyapmbuILIOXXxiSh7Y.jpg","backdrop_path":"/3QJMI8nqQcwU5JBPy26m8TUXtTN.jpg"},"budget":16500000,"genres":[{"id":878,"name":"Science
+        Fiction"},{"id":35,"name":"Comedy"},{"id":80,"name":"Crime"}],"homepage":"","id":816,"imdb_id":"tt0118655","original_language":"en","original_title":"Austin
+        Powers: International Man of Mystery","overview":"As a swingin'' fashion photographer
+        by day and a groovy British superagent by night, Austin Powers is the ''60s''
+        most shagadelic spy, baby! But can he stop megalomaniac Dr. Evil after the
+        bald villain freezes himself and unthaws in the ''90s? With the help of sexy
+        sidekick Vanessa Kensington, he just might.","popularity":16.862,"poster_path":"/5uD4dxNX8JKFjWKYMHyOsqhi5pN.jpg","production_companies":[{"id":12,"logo_path":"/iaYpEp3LQmb8AfAtmTvpqd4149c.png","name":"New
+        Line Cinema","origin_country":"US"},{"id":594,"logo_path":null,"name":"Capella
+        International","origin_country":""},{"id":595,"logo_path":null,"name":"Eric''s
+        Boy","origin_country":""}],"production_countries":[{"iso_3166_1":"DE","name":"Germany"},{"iso_3166_1":"US","name":"United
+        States of America"}],"release_date":"1997-05-02","revenue":67683989,"runtime":94,"spoken_languages":[{"english_name":"English","iso_639_1":"en","name":"English"}],"status":"Released","tagline":"If
+        he were any cooler, he''d still be frozen, baby!","title":"Austin Powers:
+        International Man of Mystery","video":false,"vote_average":6.5,"vote_count":2357}'
+  recorded_at: Sat, 17 Apr 2021 00:42:51 GMT
+- request:
+    method: get
+    uri: https://api.themoviedb.org/3/movie/242582?api_key=<TMDB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.3.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 16 Apr 2021 23:55:48 GMT
+      Server:
+      - openresty
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, PUT, DELETE, OPTIONS
+      Access-Control-Expose-Headers:
+      - ETag, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After,
+        Content-Length, Content-Range
+      Cache-Control:
+      - public, max-age=21600
+      X-Memc:
+      - HIT
+      X-Memc-Key:
+      - bb1ff11e7cc6fbdf29b77181cf5b1337bc3f3941
+      X-Memc-Age:
+      - '15501'
+      X-Memc-Expires:
+      - '6099'
+      Etag:
+      - W/"ed079ab698c2ce0ccaf164d4f5ed10ff"
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - Hit from cloudfront
+      Via:
+      - 1.1 94bd5e4f47540501369a53d4ae35d3b3.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - DEN50-C2
+      X-Amz-Cf-Id:
+      - C_NLJQyPagCmQdUn6T4xbkSQrqkmXSd9zUhzMrlu00RAxyZ4qQiQOg==
+      Age:
+      - '2824'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"adult":false,"backdrop_path":"/3kEfSOwBYhb11APEG0aUDysvW8F.jpg","belongs_to_collection":null,"budget":8500000,"genres":[{"id":80,"name":"Crime"},{"id":18,"name":"Drama"},{"id":53,"name":"Thriller"}],"homepage":"http://nightcrawlerfilm.com","id":242582,"imdb_id":"tt2872718","original_language":"en","original_title":"Nightcrawler","overview":"When
+        Lou Bloom, desperate for work, muscles into the world of L.A. crime journalism,
+        he blurs the line between observer and participant to become the star of his
+        own story. Aiding him in his effort is Nina, a TV-news veteran.","popularity":27.494,"poster_path":"/j9HrX8f7GbZQm1BrBiR40uFQZSb.jpg","production_companies":[{"id":24049,"logo_path":"/zOHQ0A3PpNoLLeAxRZwSqNV3nPr.png","name":"Sierra/Affinity","origin_country":"US"},{"id":2266,"logo_path":"/owzVs2mguyyJ3vIn7EbgowpUPnk.png","name":"Bold
+        Films","origin_country":"US"}],"production_countries":[{"iso_3166_1":"US","name":"United
+        States of America"}],"release_date":"2014-10-23","revenue":50300000,"runtime":118,"spoken_languages":[{"english_name":"English","iso_639_1":"en","name":"English"}],"status":"Released","tagline":"The
+        city shines brightest at night","title":"Nightcrawler","video":false,"vote_average":7.7,"vote_count":7971}'
+  recorded_at: Sat, 17 Apr 2021 00:42:52 GMT
+- request:
+    method: get
+    uri: https://api.themoviedb.org/3/movie/266856?api_key=<TMDB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.3.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 16 Apr 2021 23:55:48 GMT
+      Server:
+      - openresty
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, PUT, DELETE, OPTIONS
+      Access-Control-Expose-Headers:
+      - ETag, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After,
+        Content-Length, Content-Range
+      Cache-Control:
+      - public, max-age=21600
+      X-Memc:
+      - HIT
+      X-Memc-Key:
+      - 4aaacececdac005066b41b9957150a9dcd5f36f3
+      X-Memc-Age:
+      - '19299'
+      X-Memc-Expires:
+      - '2301'
+      Etag:
+      - W/"351c80bd8bdc11cafb0f4a5d70842242"
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - Hit from cloudfront
+      Via:
+      - 1.1 0f653303bc95b26f01daff2926667902.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - DEN50-C2
+      X-Amz-Cf-Id:
+      - cxkXJZHTMg4b44rJCo02GYL1vZe5aUrgU7gOm_6WiahhHWClbGZKkQ==
+      Age:
+      - '2824'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJhZHVsdCI6ZmFsc2UsImJhY2tkcm9wX3BhdGgiOiIvakU0M0w5bmk0T1doandYY0RsRUtrVm5mc2NXLmpwZyIsImJlbG9uZ3NfdG9fY29sbGVjdGlvbiI6bnVsbCwiYnVkZ2V0IjoxNTAwMDAwMCwiZ2VucmVzIjpbeyJpZCI6MTgsIm5hbWUiOiJEcmFtYSJ9LHsiaWQiOjEwNzQ5LCJuYW1lIjoiUm9tYW5jZSJ9XSwiaG9tZXBhZ2UiOiJodHRwOi8vd3d3LmZvY3VzZmVhdHVyZXMuY29tL3RoZV90aGVvcnlfb2ZfZXZlcnl0aGluZyIsImlkIjoyNjY4NTYsImltZGJfaWQiOiJ0dDI5ODA1MTYiLCJvcmlnaW5hbF9sYW5ndWFnZSI6ImVuIiwib3JpZ2luYWxfdGl0bGUiOiJUaGUgVGhlb3J5IG9mIEV2ZXJ5dGhpbmciLCJvdmVydmlldyI6IlRoZSBUaGVvcnkgb2YgRXZlcnl0aGluZyBpcyB0aGUgZXh0cmFvcmRpbmFyeSBzdG9yeSBvZiBvbmUgb2YgdGhlIHdvcmxk4oCZcyBncmVhdGVzdCBsaXZpbmcgbWluZHMsIHRoZSByZW5vd25lZCBhc3Ryb3BoeXNpY2lzdCBTdGVwaGVuIEhhd2tpbmcsIHdobyBmYWxscyBkZWVwbHkgaW4gbG92ZSB3aXRoIGZlbGxvdyBDYW1icmlkZ2Ugc3R1ZGVudCBKYW5lIFdpbGRlLiIsInBvcHVsYXJpdHkiOjIyLjY3NywicG9zdGVyX3BhdGgiOiIva0p1TDM3TlRFNTF6VlAzZUc1YUdNeUtBSWxoLmpwZyIsInByb2R1Y3Rpb25fY29tcGFuaWVzIjpbeyJpZCI6MTAxNjMsImxvZ29fcGF0aCI6Ii8xNktXQk1tZlBYMGFKekRFeERyUHhTTGowUGcucG5nIiwibmFtZSI6IldvcmtpbmcgVGl0bGUgRmlsbXMiLCJvcmlnaW5fY291bnRyeSI6IkdCIn1dLCJwcm9kdWN0aW9uX2NvdW50cmllcyI6W3siaXNvXzMxNjZfMSI6IkdCIiwibmFtZSI6IlVuaXRlZCBLaW5nZG9tIn1dLCJyZWxlYXNlX2RhdGUiOiIyMDE0LTExLTI2IiwicmV2ZW51ZSI6MTIzNzI2Njg4LCJydW50aW1lIjoxMjMsInNwb2tlbl9sYW5ndWFnZXMiOlt7ImVuZ2xpc2hfbmFtZSI6IkxhdGluIiwiaXNvXzYzOV8xIjoibGEiLCJuYW1lIjoiTGF0aW4ifSx7ImVuZ2xpc2hfbmFtZSI6IkVuZ2xpc2giLCJpc29fNjM5XzEiOiJlbiIsIm5hbWUiOiJFbmdsaXNoIn0seyJlbmdsaXNoX25hbWUiOiJGcmVuY2giLCJpc29fNjM5XzEiOiJmciIsIm5hbWUiOiJGcmFuw6dhaXMifSx7ImVuZ2xpc2hfbmFtZSI6Ikl0YWxpYW4iLCJpc29fNjM5XzEiOiJpdCIsIm5hbWUiOiJJdGFsaWFubyJ9XSwic3RhdHVzIjoiUmVsZWFzZWQiLCJ0YWdsaW5lIjoiSGlzIE1pbmQgQ2hhbmdlZCBPdXIgV29ybGQuIEhlciBMb3ZlIENoYW5nZWQgSGlzLiIsInRpdGxlIjoiVGhlIFRoZW9yeSBvZiBFdmVyeXRoaW5nIiwidmlkZW8iOmZhbHNlLCJ2b3RlX2F2ZXJhZ2UiOjcuOSwidm90ZV9jb3VudCI6ODUzOX0=
+  recorded_at: Sat, 17 Apr 2021 00:42:52 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Movies_API/can_populate_details_for_incomplete_movies.yml
+++ b/spec/fixtures/vcr_cassettes/Movies_API/can_populate_details_for_incomplete_movies.yml
@@ -1,0 +1,208 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.themoviedb.org/3/movie/816?api_key=<TMDB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.3.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 16 Apr 2021 20:43:27 GMT
+      Server:
+      - openresty
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, PUT, DELETE, OPTIONS
+      Access-Control-Expose-Headers:
+      - ETag, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After,
+        Content-Length, Content-Range
+      Cache-Control:
+      - public, max-age=21600
+      X-Memc:
+      - HIT
+      X-Memc-Key:
+      - d485a21da9c0e054971e82e13703bebab13cca1f
+      X-Memc-Age:
+      - '13358'
+      X-Memc-Expires:
+      - '8242'
+      Etag:
+      - W/"50d526eaa1cf34d9ce498fac9f6208f7"
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - Hit from cloudfront
+      Via:
+      - 1.1 9c7e5857d78c5dc89042979317de5843.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - DEN50-C2
+      X-Amz-Cf-Id:
+      - 7QTWIz_cK1BDtVT5C4EVb5zoYkIkAtCKuVOvn1S8ytT9E-0NXILWbA==
+      Age:
+      - '11541'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"adult":false,"backdrop_path":"/tsxwVsl9BYxy9y1AtxpM7xpNiC8.jpg","belongs_to_collection":{"id":1006,"name":"Austin
+        Powers Collection","poster_path":"/1PkGnyFwRyapmbuILIOXXxiSh7Y.jpg","backdrop_path":"/3QJMI8nqQcwU5JBPy26m8TUXtTN.jpg"},"budget":16500000,"genres":[{"id":878,"name":"Science
+        Fiction"},{"id":35,"name":"Comedy"},{"id":80,"name":"Crime"}],"homepage":"","id":816,"imdb_id":"tt0118655","original_language":"en","original_title":"Austin
+        Powers: International Man of Mystery","overview":"As a swingin'' fashion photographer
+        by day and a groovy British superagent by night, Austin Powers is the ''60s''
+        most shagadelic spy, baby! But can he stop megalomaniac Dr. Evil after the
+        bald villain freezes himself and unthaws in the ''90s? With the help of sexy
+        sidekick Vanessa Kensington, he just might.","popularity":16.862,"poster_path":"/5uD4dxNX8JKFjWKYMHyOsqhi5pN.jpg","production_companies":[{"id":12,"logo_path":"/iaYpEp3LQmb8AfAtmTvpqd4149c.png","name":"New
+        Line Cinema","origin_country":"US"},{"id":594,"logo_path":null,"name":"Capella
+        International","origin_country":""},{"id":595,"logo_path":null,"name":"Eric''s
+        Boy","origin_country":""}],"production_countries":[{"iso_3166_1":"DE","name":"Germany"},{"iso_3166_1":"US","name":"United
+        States of America"}],"release_date":"1997-05-02","revenue":67683989,"runtime":94,"spoken_languages":[{"english_name":"English","iso_639_1":"en","name":"English"}],"status":"Released","tagline":"If
+        he were any cooler, he''d still be frozen, baby!","title":"Austin Powers:
+        International Man of Mystery","video":false,"vote_average":6.5,"vote_count":2357}'
+  recorded_at: Fri, 16 Apr 2021 23:55:47 GMT
+- request:
+    method: get
+    uri: https://api.themoviedb.org/3/movie/242582?api_key=<TMDB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.3.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 16 Apr 2021 23:55:48 GMT
+      Server:
+      - openresty
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, PUT, DELETE, OPTIONS
+      Access-Control-Expose-Headers:
+      - ETag, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After,
+        Content-Length, Content-Range
+      Cache-Control:
+      - public, max-age=21600
+      X-Memc:
+      - HIT
+      X-Memc-Key:
+      - bb1ff11e7cc6fbdf29b77181cf5b1337bc3f3941
+      X-Memc-Age:
+      - '15501'
+      X-Memc-Expires:
+      - '6099'
+      Etag:
+      - W/"ed079ab698c2ce0ccaf164d4f5ed10ff"
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 c4fb40b7909e4dd897bba2e297b284e7.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - DEN50-C2
+      X-Amz-Cf-Id:
+      - rEHfnzM-DpODreCAHTMMs1z1TR_5KaK6aWPB36WktIxS9a_pZIBPPw==
+    body:
+      encoding: ASCII-8BIT
+      string: '{"adult":false,"backdrop_path":"/3kEfSOwBYhb11APEG0aUDysvW8F.jpg","belongs_to_collection":null,"budget":8500000,"genres":[{"id":80,"name":"Crime"},{"id":18,"name":"Drama"},{"id":53,"name":"Thriller"}],"homepage":"http://nightcrawlerfilm.com","id":242582,"imdb_id":"tt2872718","original_language":"en","original_title":"Nightcrawler","overview":"When
+        Lou Bloom, desperate for work, muscles into the world of L.A. crime journalism,
+        he blurs the line between observer and participant to become the star of his
+        own story. Aiding him in his effort is Nina, a TV-news veteran.","popularity":27.494,"poster_path":"/j9HrX8f7GbZQm1BrBiR40uFQZSb.jpg","production_companies":[{"id":24049,"logo_path":"/zOHQ0A3PpNoLLeAxRZwSqNV3nPr.png","name":"Sierra/Affinity","origin_country":"US"},{"id":2266,"logo_path":"/owzVs2mguyyJ3vIn7EbgowpUPnk.png","name":"Bold
+        Films","origin_country":"US"}],"production_countries":[{"iso_3166_1":"US","name":"United
+        States of America"}],"release_date":"2014-10-23","revenue":50300000,"runtime":118,"spoken_languages":[{"english_name":"English","iso_639_1":"en","name":"English"}],"status":"Released","tagline":"The
+        city shines brightest at night","title":"Nightcrawler","video":false,"vote_average":7.7,"vote_count":7971}'
+  recorded_at: Fri, 16 Apr 2021 23:55:48 GMT
+- request:
+    method: get
+    uri: https://api.themoviedb.org/3/movie/266856?api_key=<TMDB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.3.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Date:
+      - Fri, 16 Apr 2021 23:55:48 GMT
+      Server:
+      - openresty
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, PUT, DELETE, OPTIONS
+      Access-Control-Expose-Headers:
+      - ETag, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After,
+        Content-Length, Content-Range
+      Cache-Control:
+      - public, max-age=21600
+      X-Memc:
+      - HIT
+      X-Memc-Key:
+      - 4aaacececdac005066b41b9957150a9dcd5f36f3
+      X-Memc-Age:
+      - '19299'
+      X-Memc-Expires:
+      - '2301'
+      Etag:
+      - W/"351c80bd8bdc11cafb0f4a5d70842242"
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 1e5c934b70471a41d2b61ae8c4abeb79.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - DEN50-C2
+      X-Amz-Cf-Id:
+      - 74a-Xe8ZVc-WwdJLqMKOLg4ZU9nzvGvH1VoETK5ghAlAQ3nO-Qad_g==
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJhZHVsdCI6ZmFsc2UsImJhY2tkcm9wX3BhdGgiOiIvakU0M0w5bmk0T1doandYY0RsRUtrVm5mc2NXLmpwZyIsImJlbG9uZ3NfdG9fY29sbGVjdGlvbiI6bnVsbCwiYnVkZ2V0IjoxNTAwMDAwMCwiZ2VucmVzIjpbeyJpZCI6MTgsIm5hbWUiOiJEcmFtYSJ9LHsiaWQiOjEwNzQ5LCJuYW1lIjoiUm9tYW5jZSJ9XSwiaG9tZXBhZ2UiOiJodHRwOi8vd3d3LmZvY3VzZmVhdHVyZXMuY29tL3RoZV90aGVvcnlfb2ZfZXZlcnl0aGluZyIsImlkIjoyNjY4NTYsImltZGJfaWQiOiJ0dDI5ODA1MTYiLCJvcmlnaW5hbF9sYW5ndWFnZSI6ImVuIiwib3JpZ2luYWxfdGl0bGUiOiJUaGUgVGhlb3J5IG9mIEV2ZXJ5dGhpbmciLCJvdmVydmlldyI6IlRoZSBUaGVvcnkgb2YgRXZlcnl0aGluZyBpcyB0aGUgZXh0cmFvcmRpbmFyeSBzdG9yeSBvZiBvbmUgb2YgdGhlIHdvcmxk4oCZcyBncmVhdGVzdCBsaXZpbmcgbWluZHMsIHRoZSByZW5vd25lZCBhc3Ryb3BoeXNpY2lzdCBTdGVwaGVuIEhhd2tpbmcsIHdobyBmYWxscyBkZWVwbHkgaW4gbG92ZSB3aXRoIGZlbGxvdyBDYW1icmlkZ2Ugc3R1ZGVudCBKYW5lIFdpbGRlLiIsInBvcHVsYXJpdHkiOjIyLjY3NywicG9zdGVyX3BhdGgiOiIva0p1TDM3TlRFNTF6VlAzZUc1YUdNeUtBSWxoLmpwZyIsInByb2R1Y3Rpb25fY29tcGFuaWVzIjpbeyJpZCI6MTAxNjMsImxvZ29fcGF0aCI6Ii8xNktXQk1tZlBYMGFKekRFeERyUHhTTGowUGcucG5nIiwibmFtZSI6IldvcmtpbmcgVGl0bGUgRmlsbXMiLCJvcmlnaW5fY291bnRyeSI6IkdCIn1dLCJwcm9kdWN0aW9uX2NvdW50cmllcyI6W3siaXNvXzMxNjZfMSI6IkdCIiwibmFtZSI6IlVuaXRlZCBLaW5nZG9tIn1dLCJyZWxlYXNlX2RhdGUiOiIyMDE0LTExLTI2IiwicmV2ZW51ZSI6MTIzNzI2Njg4LCJydW50aW1lIjoxMjMsInNwb2tlbl9sYW5ndWFnZXMiOlt7ImVuZ2xpc2hfbmFtZSI6IkxhdGluIiwiaXNvXzYzOV8xIjoibGEiLCJuYW1lIjoiTGF0aW4ifSx7ImVuZ2xpc2hfbmFtZSI6IkVuZ2xpc2giLCJpc29fNjM5XzEiOiJlbiIsIm5hbWUiOiJFbmdsaXNoIn0seyJlbmdsaXNoX25hbWUiOiJGcmVuY2giLCJpc29fNjM5XzEiOiJmciIsIm5hbWUiOiJGcmFuw6dhaXMifSx7ImVuZ2xpc2hfbmFtZSI6Ikl0YWxpYW4iLCJpc29fNjM5XzEiOiJpdCIsIm5hbWUiOiJJdGFsaWFubyJ9XSwic3RhdHVzIjoiUmVsZWFzZWQiLCJ0YWdsaW5lIjoiSGlzIE1pbmQgQ2hhbmdlZCBPdXIgV29ybGQuIEhlciBMb3ZlIENoYW5nZWQgSGlzLiIsInRpdGxlIjoiVGhlIFRoZW9yeSBvZiBFdmVyeXRoaW5nIiwidmlkZW8iOmZhbHNlLCJ2b3RlX2F2ZXJhZ2UiOjcuOSwidm90ZV9jb3VudCI6ODUzOX0=
+  recorded_at: Fri, 16 Apr 2021 23:55:48 GMT
+recorded_with: VCR 6.0.0

--- a/spec/jobs/movie_details_update_job_spec.rb
+++ b/spec/jobs/movie_details_update_job_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe MovieDetailsUpdateJob, type: :job do
+  it 'populates details for incomplete movies', :vcr do
+    movies = []
+    movies << Movie.create(
+      title: 'Austin Powers: International Man of Mystery',
+      tmdb_id: 816
+    )
+    movies << Movie.create(
+      title: 'Nightcrawler',
+      tmdb_id: 242582
+    )
+    movies << Movie.create(
+      title: 'The Theory of Everything',
+      tmdb_id: 266856
+    )
+
+    MovieDetailsUpdateJob.perform_now(movies)
+
+    austin_powers = Movie.find_by(tmdb_id:816)
+    nightcrawler = Movie.find_by(tmdb_id:242582)
+    theory_of_everything = Movie.find_by(tmdb_id:266856)
+    updated_movies = [austin_powers, nightcrawler, theory_of_everything]
+
+    # tests movie objects have been updated
+    updated_movies.each do |movie|
+      expect(movie.poster_path).to be_a(String)
+      expect(movie.description).to be_a(String)
+      expect(movie.vote_average).to be_a(Float)
+      expect(movie.vote_count).to be_a(Integer)
+      expect(movie.year).to be_a(String)
+      expect(movie.genres).not_to eq([])
+    end
+  end
+end

--- a/spec/models/genre_spec.rb
+++ b/spec/models/genre_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe Genre, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of :name}
+  end
+
+  describe 'relationships' do
+    it do
+      should have_many :movie_genres
+      should have_many(:movies).through(:movie_genres)
+    end
+  end
+end

--- a/spec/models/movie_genre_spec.rb
+++ b/spec/models/movie_genre_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe MovieGenre, type: :model do
+  describe 'relationships' do
+    it do
+      should belong_to :movie
+      should belong_to :genre
+    end
+  end
+end

--- a/spec/models/movie_spec.rb
+++ b/spec/models/movie_spec.rb
@@ -10,6 +10,8 @@ describe Movie, type: :model do
     it do
       should have_many :movie_availabilities
       should have_many(:services).through(:movie_availabilities)
+      should have_many :movie_genres
+      should have_many(:genres).through(:movie_genres)
     end
   end
 end

--- a/spec/requests/api/v1/movies_request_spec.rb
+++ b/spec/requests/api/v1/movies_request_spec.rb
@@ -205,7 +205,7 @@ describe "Movies API" do
     expect(json).to have_key(:movies_updated)
     expect(json[:movies_updated]).to eq(3)
     expect(json).to have_key(:update_status)
-    expect(json[:update_status]).to eq("In progress - it may take several minutes for the database to be fully updated.")
+    expect(json[:update_status]).to eq('Complete - incomplete movies have been populated.')
 
     austin_powers = Movie.find_by(tmdb_id:816)
     nightcrawler = Movie.find_by(tmdb_id:242582)

--- a/spec/requests/api/v1/movies_request_spec.rb
+++ b/spec/requests/api/v1/movies_request_spec.rb
@@ -28,8 +28,6 @@ describe "Movies API" do
       expect(movie_data[:attributes][:poster_path]).to be_a(String)
       expect(movie_data[:attributes]).to have_key(:description)
       expect(movie_data[:attributes][:description]).to be_a(String)
-      expect(movie_data[:attributes]).to have_key(:genres)
-      expect(movie_data[:attributes][:genres]).to be_a(String)
       expect(movie_data[:attributes]).to have_key(:vote_average)
       expect(movie_data[:attributes][:vote_average]).to be_a(Float)
       expect(movie_data[:attributes]).to have_key(:vote_count)
@@ -71,8 +69,6 @@ describe "Movies API" do
     expect(json[:data][:attributes][:poster_path]).to eq(nil)
     expect(json[:data][:attributes]).to have_key(:description)
     expect(json[:data][:attributes][:description]).to eq(nil)
-    expect(json[:data][:attributes]).to have_key(:genres)
-    expect(json[:data][:attributes][:genres]).to eq(nil)
     expect(json[:data][:attributes]).to have_key(:vote_average)
     expect(json[:data][:attributes][:vote_average]).to eq(nil)
     expect(json[:data][:attributes]).to have_key(:vote_count)
@@ -114,8 +110,6 @@ describe "Movies API" do
     expect(json[:data][:attributes][:poster_path]).to eq(nil)
     expect(json[:data][:attributes]).to have_key(:description)
     expect(json[:data][:attributes][:description]).to eq(nil)
-    expect(json[:data][:attributes]).to have_key(:genres)
-    expect(json[:data][:attributes][:genres]).to eq(nil)
     expect(json[:data][:attributes]).to have_key(:vote_average)
     expect(json[:data][:attributes][:vote_average]).to eq(nil)
     expect(json[:data][:attributes]).to have_key(:vote_count)
@@ -133,7 +127,6 @@ describe "Movies API" do
     movie_params = ({
       poster_path: '/1PkGnyFwRyapmbuILIOXXxiSh7Y.jpg',
       description: "As a swingin' fashion photographer by day and a groovy British superagent by night, Austin Powers is the '60s' most shagadelic spy, baby! But can he stop megalomaniac Dr. Evil after the bald villain freezes himself and unthaws in the '90s? With the help of sexy sidekick Vanessa Kensington, he just might.",
-      genres: 'Comedy',
       vote_average: 6.5,
       vote_count: 2349,
       year: '1997'
@@ -165,8 +158,6 @@ describe "Movies API" do
     expect(json[:data][:attributes][:poster_path]).to eq(movie_params[:poster_path])
     expect(json[:data][:attributes]).to have_key(:description)
     expect(json[:data][:attributes][:description]).to eq(movie_params[:description])
-    expect(json[:data][:attributes]).to have_key(:genres)
-    expect(json[:data][:attributes][:genres]).to eq(movie_params[:genres])
     expect(json[:data][:attributes]).to have_key(:vote_average)
     expect(json[:data][:attributes][:vote_average]).to eq(movie_params[:vote_average])
     expect(json[:data][:attributes]).to have_key(:vote_count)


### PR DESCRIPTION
This PR will:
* Move movie genre information from movie table into a new genre table and a new movie genre joins table (this enables multiple genres per movie, and forthcoming genre sorting)
* Create new GET '/movies/populate_details endpoint' to fetch movie data from the TMDB external API, and integrate it into the database
* Create new active job to process bulky populate_details requests with background workers
* Add tests for model changes, new endpoint and new job
