### PR TITLE
Group movies

### DIFF
--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -21,6 +21,11 @@ class Api::V1::GroupsController < ApplicationController
     Group.destroy(params[:id])
   end
 
+  def matches
+    matches = Movie.group_matches(params[:id])
+    render json: MovieSerializer.new(matches)
+  end
+
   private
 
   def group_params

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::GroupsController < ApplicationController
 
   def matches
     matches = Movie.group_matches(params[:id])
-    render json: MovieSerializer.new(matches)
+    render json: MatchSerializer.new(matches)
   end
 
   private

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -62,4 +62,21 @@ class Movie < ApplicationRecord
       nil
     end
   end
+
+  def self.group_right_swiped(group_id)
+    # REFACTOR - change to activerecord
+    group = Group.find(group_id)
+    right_swiped = Set.new
+    left_swiped = Set.new
+    group.users.each do |user|
+      user.swipes.each do |swipe|
+        if swipe.rating == 1
+          right_swiped << swipe.movie
+        elsif swipe.rating == 0
+          left_swiped << swipe.movie
+        end
+      end
+    end
+    (right_swiped - left_swiped).to_a
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -77,6 +77,14 @@ class Movie < ApplicationRecord
         end
       end
     end
-    (right_swiped - left_swiped).to_a
+    valid_movies = (right_swiped - left_swiped).to_a
+    group.users.each do |user|
+      valid_movies.each do |movie|
+        unless user.movies.include?(movie)
+          valid_movies.delete(movie)
+        end
+      end
+    end
+    valid_movies
   end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -78,13 +78,14 @@ class Movie < ApplicationRecord
       end
     end
     valid_movies = (right_swiped - left_swiped).to_a
+    invalid_movies = []
     group.users.each do |user|
       valid_movies.each do |movie|
         unless user.movies.include?(movie)
-          valid_movies.delete(movie)
+          invalid_movies << movie
         end
       end
     end
-    valid_movies
+    valid_movies - invalid_movies
   end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -63,7 +63,7 @@ class Movie < ApplicationRecord
     end
   end
 
-  def self.group_right_swiped(group_id)
+  def self.group_matches(group_id)
     # REFACTOR - change to activerecord
     group = Group.find(group_id)
     right_swiped = Set.new

--- a/app/serializers/match_serializer.rb
+++ b/app/serializers/match_serializer.rb
@@ -1,0 +1,4 @@
+class MatchSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :title, :tmdb_id, :poster_path, :description, :genres, :vote_average, :vote_count, :year, :services
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
       end
 
       # groups routes
+      get '/groups/:id/matches', to: 'groups#matches'
       resources :groups, only: [:create, :destroy, :show]
 
       # user_groups routes

--- a/spec/fixtures/vcr_cassettes/services_API/can_update_availability.yml
+++ b/spec/fixtures/vcr_cassettes/services_API/can_update_availability.yml
@@ -73,7 +73,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 07 May 2021 03:02:07 GMT
+      - Sat, 08 May 2021 23:04:42 GMT
       Server:
       - Apache/2.4.46 (Ubuntu)
       Access-Control-Allow-Origin:
@@ -87,11 +87,11 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '120'
       Retry-After:
-      - '53'
+      - '18'
       X-Account-Quota:
       - '1000'
       X-Account-Quota-Used:
-      - '469'
+      - '477'
       Vary:
       - Accept-Encoding
       Transfer-Encoding:
@@ -112,11 +112,11 @@ http_interactions:
         Expendables","year":2010,"imdb_id":"tt1320253","tmdb_id":27578,"tmdb_type":"movie","type":"movie"},{"id":1359837,"title":"Status
         Update","year":2018,"imdb_id":"tt5692390","tmdb_id":416494,"tmdb_type":"movie","type":"movie"},{"id":1244451,"title":"Man
         of La Mancha","year":1972,"imdb_id":"tt0068909","tmdb_id":45793,"tmdb_type":"movie","type":"movie"},{"id":1458017,"title":"Virtuosity","year":1995,"imdb_id":"tt0114857","tmdb_id":9271,"tmdb_type":"movie","type":"movie"},{"id":1511146,"title":"Clemency","year":2019,"imdb_id":"tt5577494","tmdb_id":565307,"tmdb_type":"movie","type":"movie"},{"id":1534156,"title":"Marianne
-        & Leonard: Words of Love","year":2019,"imdb_id":"tt9358196","tmdb_id":566230,"tmdb_type":"movie","type":"movie"},{"id":1614581,"title":"Rogue","year":2020,"imdb_id":"tt11576124","tmdb_id":718444,"tmdb_type":"movie","type":"movie"},{"id":1319079,"title":"Regarding
+        & Leonard: Words of Love","year":2019,"imdb_id":"tt9358196","tmdb_id":566230,"tmdb_type":"movie","type":"movie"},{"id":1614581,"title":"Rogue","year":2020,"imdb_id":"tt11576124","tmdb_id":718444,"tmdb_type":"movie","type":"movie"},{"id":1497770,"title":"Lucky
+        Day","year":2019,"imdb_id":"tt7248248","tmdb_id":477508,"tmdb_type":"movie","type":"movie"},{"id":1319079,"title":"Regarding
         Henry","year":1991,"imdb_id":"tt0102768","tmdb_id":11364,"tmdb_type":"movie","type":"movie"},{"id":1496005,"title":"Buddy
         Games","year":2019,"imdb_id":"tt7070818","tmdb_id":472815,"tmdb_type":"movie","type":"movie"},{"id":1367762,"title":"The
-        Warrior Queen of Jhansi","year":2019,"imdb_id":"tt6916348","tmdb_id":530183,"tmdb_type":"movie","type":"movie"},{"id":1497770,"title":"Lucky
-        Day","year":2019,"imdb_id":"tt7248248","tmdb_id":477508,"tmdb_type":"movie","type":"movie"},{"id":1331248,"title":"Salt","year":2010,"imdb_id":"tt0944835","tmdb_id":27576,"tmdb_type":"movie","type":"movie"},{"id":191695,"title":"Date
+        Warrior Queen of Jhansi","year":2019,"imdb_id":"tt6916348","tmdb_id":530183,"tmdb_type":"movie","type":"movie"},{"id":1331248,"title":"Salt","year":2010,"imdb_id":"tt0944835","tmdb_id":27576,"tmdb_type":"movie","type":"movie"},{"id":191695,"title":"Date
         Night","year":2010,"imdb_id":"tt1279935","tmdb_id":35056,"tmdb_type":"movie","type":"movie"},{"id":1579858,"title":"Spontaneous","year":2020,"imdb_id":"tt5774062","tmdb_id":604578,"tmdb_type":"movie","type":"movie"},{"id":1414186,"title":"The
         Quake","year":2018,"imdb_id":"tt6523720","tmdb_id":416194,"tmdb_type":"movie","type":"movie"},{"id":1354000,"title":"Someone
         Marry Barry","year":2014,"imdb_id":"tt1978532","tmdb_id":249923,"tmdb_type":"movie","type":"movie"},{"id":129642,"title":"Aniara","year":2018,"imdb_id":"tt7589524","tmdb_id":496743,"tmdb_type":"movie","type":"movie"},{"id":1552022,"title":"Plus
@@ -139,8 +139,7 @@ http_interactions:
         Irons: Kissed by God","year":2018,"imdb_id":"tt8961266","tmdb_id":522538,"tmdb_type":"movie","type":"movie"},{"id":1396160,"title":"The
         Hangman","year":1959,"imdb_id":"tt0052877","tmdb_id":48409,"tmdb_type":"movie","type":"movie"},{"id":1404066,"title":"The
         Lonely Man","year":1957,"imdb_id":"tt0050652","tmdb_id":43250,"tmdb_type":"movie","type":"movie"},{"id":1135966,"title":"Flower","year":2017,"imdb_id":"tt2582784","tmdb_id":421471,"tmdb_type":"movie","type":"movie"},{"id":1414637,"title":"The
-        Rape of Recy Taylor","year":2017,"imdb_id":"tt6116682","tmdb_id":472648,"tmdb_type":"movie","type":"movie"},{"id":1572079,"title":"CRSHD","year":2019,"imdb_id":"tt8315302","tmdb_id":592043,"tmdb_type":"movie","type":"movie"},{"id":1165686,"title":"Hillbilly","year":2018,"imdb_id":"tt8218940","tmdb_id":525232,"tmdb_type":"movie","type":"movie"},{"id":1271435,"title":"Neat:
-        The Story of Bourbon","year":2018,"imdb_id":"tt7109844","tmdb_id":506730,"tmdb_type":"movie","type":"movie"},{"id":1377199,"title":"The
+        Rape of Recy Taylor","year":2017,"imdb_id":"tt6116682","tmdb_id":472648,"tmdb_type":"movie","type":"movie"},{"id":1572079,"title":"CRSHD","year":2019,"imdb_id":"tt8315302","tmdb_id":592043,"tmdb_type":"movie","type":"movie"},{"id":1165686,"title":"Hillbilly","year":2018,"imdb_id":"tt8218940","tmdb_id":525232,"tmdb_type":"movie","type":"movie"},{"id":1377199,"title":"The
         Appearance","year":2018,"imdb_id":"tt6857040","tmdb_id":524788,"tmdb_type":"movie","type":"movie"},{"id":135832,"title":"Astral","year":2018,"imdb_id":"tt4765240","tmdb_id":419407,"tmdb_type":"movie","type":"movie"},{"id":1403373,"title":"The
         Limehouse Golem","year":2016,"imdb_id":"tt4733640","tmdb_id":369300,"tmdb_type":"movie","type":"movie"},{"id":1410796,"title":"The
         Osiris Child","year":2016,"imdb_id":"tt4536768","tmdb_id":354282,"tmdb_type":"movie","type":"movie"},{"id":1411526,"title":"The
@@ -215,8 +214,7 @@ http_interactions:
         or The Making and Breaking of a $47 Billion Unicorn","year":2021,"imdb_id":"tt11188154","tmdb_id":795622,"tmdb_type":"movie","type":"movie"},{"id":1629004,"title":"kid
         90","year":2021,"imdb_id":"tt14035292","tmdb_id":795859,"tmdb_type":"movie","type":"movie"},{"id":1413016,"title":"The
         Portrait of a Lady","year":1996,"imdb_id":"tt0117364","tmdb_id":36758,"tmdb_type":"movie","type":"movie"},{"id":1255751,"title":"Minding
-        the Gap","year":2018,"imdb_id":"tt7476236","tmdb_id":489985,"tmdb_type":"movie","type":"movie"},{"id":1152822,"title":"Graveyard
-        Shift","year":1990,"imdb_id":"tt0099697","tmdb_id":19158,"tmdb_type":"movie","type":"movie"},{"id":125379,"title":"American
+        the Gap","year":2018,"imdb_id":"tt7476236","tmdb_id":489985,"tmdb_type":"movie","type":"movie"},{"id":125379,"title":"American
         Animals","year":2018,"imdb_id":"tt6212478","tmdb_id":489931,"tmdb_type":"movie","type":"movie"},{"id":1174979,"title":"I
         Saw the Devil","year":2010,"imdb_id":"tt1588170","tmdb_id":49797,"tmdb_type":"movie","type":"movie"},{"id":1582479,"title":"The
         Courier","year":2019,"imdb_id":"tt9207616","tmdb_id":611914,"tmdb_type":"movie","type":"movie"},{"id":1407221,"title":"The
@@ -264,11 +262,12 @@ http_interactions:
         Wretched","year":2019,"imdb_id":"tt8305806","tmdb_id":605804,"tmdb_type":"movie","type":"movie"},{"id":140237,"title":"Back
         to School","year":1986,"imdb_id":"tt0090685","tmdb_id":15596,"tmdb_type":"movie","type":"movie"},{"id":185127,"title":"Cruise","year":2018,"imdb_id":"tt5034122","tmdb_id":365240,"tmdb_type":"movie","type":"movie"},{"id":1148973,"title":"Glen
         Campbell: I''ll Be Me","year":2014,"imdb_id":"tt2049586","tmdb_id":285689,"tmdb_type":"movie","type":"movie"},{"id":1185129,"title":"Intrigo:
-        Samaria","year":2019,"imdb_id":"tt6341108","tmdb_id":482568,"tmdb_type":"movie","type":"movie"},{"id":1337181,"title":"Second
+        Samaria","year":2019,"imdb_id":"tt6341108","tmdb_id":482568,"tmdb_type":"movie","type":"movie"},{"id":1271435,"title":"Neat:
+        The Story of Bourbon","year":2018,"imdb_id":"tt7109844","tmdb_id":506730,"tmdb_type":"movie","type":"movie"},{"id":1337181,"title":"Second
         Chance Christmas","year":2017,"imdb_id":"tt6615240","tmdb_id":485614,"tmdb_type":"movie","type":"tv_movie"},{"id":1431354,"title":"This
         One''s for the Ladies","year":2018,"imdb_id":"tt7947150","tmdb_id":502134,"tmdb_type":"movie","type":"movie"},{"id":1586827,"title":"VHYes","year":2019,"imdb_id":"tt10287376","tmdb_id":624782,"tmdb_type":"movie","type":"movie"},{"id":1622287,"title":"The
         Assistant","year":2020,"imdb_id":"tt12838350","tmdb_id":767412,"tmdb_type":"movie","type":"movie"},{"id":1589816,"title":"Public
-        Figure","year":2019,"imdb_id":"tt8738176","tmdb_id":635231,"tmdb_type":"movie","type":"movie"},{"id":1389866,"title":"The
+        Figure","year":2019,"imdb_id":"tt8738176","tmdb_id":635231,"tmdb_type":"movie","type":"movie"},{"id":1579983,"title":"Supervized","year":2019,"imdb_id":"tt7302054","tmdb_id":605048,"tmdb_type":"movie","type":"movie"},{"id":1389866,"title":"The
         Evil in Us","year":2016,"imdb_id":"tt4035898","tmdb_id":396004,"tmdb_type":"movie","type":"movie"},{"id":1524737,"title":"Modern
         Persuasion","year":2020,"imdb_id":"tt2165922","tmdb_id":536725,"tmdb_type":"movie","type":"movie"},{"id":1583435,"title":"Stairs","year":2019,"imdb_id":"tt8439934","tmdb_id":614208,"tmdb_type":"movie","type":"movie"},{"id":1599951,"title":"The
         Legend of Baron To''a","year":2020,"imdb_id":"tt11690838","tmdb_id":673284,"tmdb_type":"movie","type":"movie"},{"id":1621643,"title":"Ip
@@ -297,8 +296,8 @@ http_interactions:
         Cam","year":2020,"imdb_id":"tt8179024","tmdb_id":513268,"tmdb_type":"movie","type":"movie"},{"id":1411811,"title":"The
         Peanut Butter Falcon","year":2019,"imdb_id":"tt4364194","tmdb_id":463257,"tmdb_type":"movie","type":"movie"},{"id":1120617,"title":"Elena
         Undone","year":2010,"imdb_id":"tt1575539","tmdb_id":56743,"tmdb_type":"movie","type":"movie"},{"id":1401825,"title":"The
-        Last Mistress","year":2007,"imdb_id":"tt0437526","tmdb_id":2002,"tmdb_type":"movie","type":"movie"}],"page":1,"total_results":1994,"total_pages":8}'
-  recorded_at: Fri, 07 May 2021 03:02:07 GMT
+        Last Mistress","year":2007,"imdb_id":"tt0437526","tmdb_id":2002,"tmdb_type":"movie","type":"movie"}],"page":1,"total_results":1980,"total_pages":8}'
+  recorded_at: Sat, 08 May 2021 23:04:42 GMT
 - request:
     method: get
     uri: https://api.watchmode.com/v1/list-titles/?apiKey=<WATCHMODE_API_KEY>&page=2&regions=US&source_ids=157&source_types=sub&type=movie
@@ -318,7 +317,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 07 May 2021 03:02:07 GMT
+      - Sat, 08 May 2021 23:04:42 GMT
       Server:
       - Apache/2.4.46 (Ubuntu)
       Access-Control-Allow-Origin:
@@ -332,11 +331,11 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '119'
       Retry-After:
-      - '53'
+      - '18'
       X-Account-Quota:
       - '1000'
       X-Account-Quota-Used:
-      - '470'
+      - '478'
       Vary:
       - Accept-Encoding
       Transfer-Encoding:
@@ -357,8 +356,7 @@ http_interactions:
         Guaranteed","year":2017,"imdb_id":"tt3715296","tmdb_id":481841,"tmdb_type":"movie","type":"movie"},{"id":116120,"title":"Across
         the Line","year":2015,"imdb_id":"tt4295258","tmdb_id":356301,"tmdb_type":"movie","type":"movie"},{"id":1410876,"title":"The
         Other Man","year":2008,"imdb_id":"tt0974613","tmdb_id":17606,"tmdb_type":"movie","type":"movie"},{"id":147585,"title":"Beneath
-        the Darkness","year":2011,"imdb_id":"tt1781775","tmdb_id":78461,"tmdb_type":"movie","type":"movie"},{"id":1172649,"title":"Hunt
-        for the Wilderpeople","year":2016,"imdb_id":"tt4698684","tmdb_id":371645,"tmdb_type":"movie","type":"movie"},{"id":1426933,"title":"The
+        the Darkness","year":2011,"imdb_id":"tt1781775","tmdb_id":78461,"tmdb_type":"movie","type":"movie"},{"id":1426933,"title":"The
         Way Back","year":2010,"imdb_id":"tt1023114","tmdb_id":49009,"tmdb_type":"movie","type":"movie"},{"id":131371,"title":"Any
         Given Sunday","year":1999,"imdb_id":"tt0146838","tmdb_id":9563,"tmdb_type":"movie","type":"movie"},{"id":1438996,"title":"Train
         to Busan","year":2016,"imdb_id":"tt5700672","tmdb_id":396535,"tmdb_type":"movie","type":"movie"},{"id":1375536,"title":"The
@@ -384,7 +382,8 @@ http_interactions:
         Ahkeem","year":2017,"imdb_id":"tt5119268","tmdb_id":440094,"tmdb_type":"movie","type":"movie"},{"id":1182064,"title":"In
         the Radiant City","year":2016,"imdb_id":"tt5033018","tmdb_id":413842,"tmdb_type":"movie","type":"movie"},{"id":1128056,"title":"F*&%
         the Prom","year":2017,"imdb_id":"tt5612742","tmdb_id":487702,"tmdb_type":"movie","type":"movie"},{"id":1287401,"title":"Ong
-        Bak: Muay Thai Warrior","year":2003,"imdb_id":"tt0368909","tmdb_id":9316,"tmdb_type":"movie","type":"movie"},{"id":1439999,"title":"Treehouse","year":2014,"imdb_id":"tt1791681","tmdb_id":286372,"tmdb_type":"movie","type":"movie"},{"id":1187198,"title":"It
+        Bak: Muay Thai Warrior","year":2003,"imdb_id":"tt0368909","tmdb_id":9316,"tmdb_type":"movie","type":"movie"},{"id":1439999,"title":"Treehouse","year":2014,"imdb_id":"tt1791681","tmdb_id":286372,"tmdb_type":"movie","type":"movie"},{"id":140153,"title":"Back
+        in Time","year":2015,"imdb_id":"tt3118874","tmdb_id":330127,"tmdb_type":"movie","type":"movie"},{"id":1187198,"title":"It
         Had to Be You","year":2015,"imdb_id":"tt4414438","tmdb_id":383208,"tmdb_type":"movie","type":"movie"},{"id":1423625,"title":"The
         Time of Their Lives","year":2017,"imdb_id":"tt3415992","tmdb_id":442353,"tmdb_type":"movie","type":"movie"},{"id":1931,"title":"10.0
         Earthquake","year":2014,"imdb_id":"tt3488056","tmdb_id":302666,"tmdb_type":"movie","type":"movie"},{"id":1439034,"title":"Traitor","year":2008,"imdb_id":"tt0988047","tmdb_id":13291,"tmdb_type":"movie","type":"movie"},{"id":168448,"title":"Cashback","year":2006,"imdb_id":"tt0460740","tmdb_id":12225,"tmdb_type":"movie","type":"movie"},{"id":1285822,"title":"Ong
@@ -402,8 +401,7 @@ http_interactions:
         Still Believe","year":2020,"imdb_id":"tt9779516","tmdb_id":585244,"tmdb_type":"movie","type":"movie"},{"id":1454217,"title":"Vantage
         Point","year":2008,"imdb_id":"tt0443274","tmdb_id":7461,"tmdb_type":"movie","type":"movie"},{"id":1397956,"title":"The
         Houses October Built 2","year":2017,"imdb_id":"tt7068818","tmdb_id":466344,"tmdb_type":"movie","type":"movie"},{"id":1238325,"title":"Lucky
-        Number Slevin","year":2006,"imdb_id":"tt0425210","tmdb_id":186,"tmdb_type":"movie","type":"movie"},{"id":1303176,"title":"Pledge","year":2018,"imdb_id":"tt6220752","tmdb_id":530157,"tmdb_type":"movie","type":"movie"},{"id":119605,"title":"Air
-        Strike","year":2018,"imdb_id":"tt4743226","tmdb_id":345934,"tmdb_type":"movie","type":"movie"},{"id":1583583,"title":"The
+        Number Slevin","year":2006,"imdb_id":"tt0425210","tmdb_id":186,"tmdb_type":"movie","type":"movie"},{"id":1303176,"title":"Pledge","year":2018,"imdb_id":"tt6220752","tmdb_id":530157,"tmdb_type":"movie","type":"movie"},{"id":1583583,"title":"The
         Dustwalker","year":2019,"imdb_id":"tt6816388","tmdb_id":614869,"tmdb_type":"movie","type":"movie"},{"id":1293976,"title":"Pandorum","year":2009,"imdb_id":"tt1188729","tmdb_id":19898,"tmdb_type":"movie","type":"movie"},{"id":1100232,"title":"Deuces
         Wild","year":2002,"imdb_id":"tt0231448","tmdb_id":13201,"tmdb_type":"movie","type":"movie"},{"id":1453982,"title":"National
         Lampoon''s Van Wilder","year":2002,"imdb_id":"tt0283111","tmdb_id":11452,"tmdb_type":"movie","type":"movie"},{"id":1302977,"title":"Playing
@@ -446,21 +444,20 @@ http_interactions:
         Mommy","year":2014,"imdb_id":"tt3086442","tmdb_id":284303,"tmdb_type":"movie","type":"movie"},{"id":153845,"title":"Blame","year":2017,"imdb_id":"tt4607722","tmdb_id":422128,"tmdb_type":"movie","type":"movie"},{"id":1409682,"title":"The
         Night Watchmen","year":2017,"imdb_id":"tt4102722","tmdb_id":398798,"tmdb_type":"movie","type":"movie"},{"id":1406337,"title":"The
         Mandela Effect","year":2019,"imdb_id":"tt6544220","tmdb_id":491037,"tmdb_type":"movie","type":"movie"},{"id":1383489,"title":"The
-        Christmas Calendar","year":2017,"imdb_id":"tt6478538","tmdb_id":488262,"tmdb_type":"movie","type":"movie"},{"id":1137540,"title":"Force
-        Majeure","year":2014,"imdb_id":"tt2121382","tmdb_id":265189,"tmdb_type":"movie","type":"movie"},{"id":1340827,"title":"Sex
+        Christmas Calendar","year":2017,"imdb_id":"tt6478538","tmdb_id":488262,"tmdb_type":"movie","type":"movie"},{"id":1340827,"title":"Sex
         Ed","year":2014,"imdb_id":"tt2751310","tmdb_id":295315,"tmdb_type":"movie","type":"movie"},{"id":1389693,"title":"The
         Escort","year":2015,"imdb_id":"tt3793788","tmdb_id":351964,"tmdb_type":"movie","type":"movie"},{"id":1266571,"title":"My
         Scientology Movie","year":2015,"imdb_id":"tt5111874","tmdb_id":359871,"tmdb_type":"movie","type":"movie"},{"id":143606,"title":"Barking
         Dogs Never Bite","year":2000,"imdb_id":"tt0269743","tmdb_id":21531,"tmdb_type":"movie","type":"movie"},{"id":1173874,"title":"I
-        Am Not Your Negro","year":2016,"imdb_id":"tt5804038","tmdb_id":411019,"tmdb_type":"movie","type":"movie"},{"id":1397523,"title":"The
-        Hornet''s Nest","year":2014,"imdb_id":"tt2611026","tmdb_id":263510,"tmdb_type":"movie","type":"movie"},{"id":1588267,"title":"James
+        Am Not Your Negro","year":2016,"imdb_id":"tt5804038","tmdb_id":411019,"tmdb_type":"movie","type":"movie"},{"id":1588267,"title":"James
         vs. His Future Self","year":2019,"imdb_id":"tt6739796","tmdb_id":629502,"tmdb_type":"movie","type":"movie"},{"id":1282936,"title":"Odd
         Thomas","year":2013,"imdb_id":"tt1767354","tmdb_id":179826,"tmdb_type":"movie","type":"movie"},{"id":176880,"title":"Citizen
         Soldier","year":2016,"imdb_id":"tt4911408","tmdb_id":406231,"tmdb_type":"movie","type":"movie"},{"id":1121194,"title":"Elvira,
         Mistress of the Dark","year":1988,"imdb_id":"tt0095088","tmdb_id":5680,"tmdb_type":"movie","type":"movie"},{"id":12106,"title":"2
         Days in Paris","year":2007,"imdb_id":"tt0841044","tmdb_id":1845,"tmdb_type":"movie","type":"movie"},{"id":146169,"title":"Before
         We Go","year":2014,"imdb_id":"tt0443465","tmdb_id":283350,"tmdb_type":"movie","type":"movie"},{"id":17732,"title":"A
-        Good Old Fashioned Orgy","year":2011,"imdb_id":"tt1231586","tmdb_id":69778,"tmdb_type":"movie","type":"movie"},{"id":1381115,"title":"The
+        Good Old Fashioned Orgy","year":2011,"imdb_id":"tt1231586","tmdb_id":69778,"tmdb_type":"movie","type":"movie"},{"id":1397523,"title":"The
+        Hornet''s Nest","year":2014,"imdb_id":"tt2611026","tmdb_id":263510,"tmdb_type":"movie","type":"movie"},{"id":1381115,"title":"The
         Boy Downstairs","year":2017,"imdb_id":"tt5096846","tmdb_id":449848,"tmdb_type":"movie","type":"movie"},{"id":1473016,"title":"XX","year":2017,"imdb_id":"tt3322892","tmdb_id":297160,"tmdb_type":"movie","type":"movie"},{"id":1104914,"title":"Dinosaur
         13","year":2014,"imdb_id":"tt3090252","tmdb_id":103015,"tmdb_type":"tv","type":"movie"},{"id":159278,"title":"Brand
         New Old Love","year":2018,"imdb_id":"tt5607810","tmdb_id":464205,"tmdb_type":"movie","type":"movie"},{"id":1165292,"title":"High
@@ -492,11 +489,12 @@ http_interactions:
         Assault","year":2017,"imdb_id":"tt3972110","tmdb_id":402243,"tmdb_type":"movie","type":"movie"},{"id":186135,"title":"Curious
         George 3: Back to the Jungle","year":2015,"imdb_id":"tt4622340","tmdb_id":338103,"tmdb_type":"movie","type":"movie"},{"id":1376091,"title":"The
         Addams Family","year":2019,"imdb_id":"tt1620981","tmdb_id":481084,"tmdb_type":"movie","type":"movie"},{"id":123615,"title":"Almost
-        Famous","year":2000,"imdb_id":"tt0181875","tmdb_id":786,"tmdb_type":"movie","type":"movie"},{"id":1597039,"title":"The
-        Great","year":2020,"imdb_id":"tt2235759","tmdb_id":93812,"tmdb_type":"tv","type":"tv_series"},{"id":1172906,"title":"Hurricane
+        Famous","year":2000,"imdb_id":"tt0181875","tmdb_id":786,"tmdb_type":"movie","type":"movie"},{"id":1172906,"title":"Hurricane
         Bianca","year":2016,"imdb_id":"tt4007248","tmdb_id":400547,"tmdb_type":"movie","type":"movie"},{"id":1413770,"title":"The
         Prodigy","year":2019,"imdb_id":"tt4504044","tmdb_id":532671,"tmdb_type":"movie","type":"movie"},{"id":130163,"title":"Anna
-        and the Apocalypse","year":2017,"imdb_id":"tt6433880","tmdb_id":461928,"tmdb_type":"movie","type":"movie"},{"id":140353,"title":"Vice","year":2018,"imdb_id":"tt6266538","tmdb_id":429197,"tmdb_type":"movie","type":"movie"},{"id":162771,"title":"Bumblebee","year":2018,"imdb_id":"tt4701182","tmdb_id":424783,"tmdb_type":"movie","type":"movie"},{"id":1417477,"title":"The
+        and the Apocalypse","year":2017,"imdb_id":"tt6433880","tmdb_id":461928,"tmdb_type":"movie","type":"movie"},{"id":140353,"title":"Vice","year":2018,"imdb_id":"tt6266538","tmdb_id":429197,"tmdb_type":"movie","type":"movie"},{"id":162771,"title":"Bumblebee","year":2018,"imdb_id":"tt4701182","tmdb_id":424783,"tmdb_type":"movie","type":"movie"},{"id":1564155,"title":"Beasts
+        Clawing at Straws","year":2020,"imdb_id":"tt9747594","tmdb_id":571648,"tmdb_type":"movie","type":"movie"},{"id":1572910,"title":"Little
+        Fish","year":2020,"imdb_id":"tt9735470","tmdb_id":586791,"tmdb_type":"movie","type":"movie"},{"id":1417477,"title":"The
         Scent of Green Papaya","year":1993,"imdb_id":"tt0107617","tmdb_id":19552,"tmdb_type":"movie","type":"movie"},{"id":18048,"title":"A
         Hologram for the King","year":2016,"imdb_id":"tt2980210","tmdb_id":270010,"tmdb_type":"movie","type":"movie"},{"id":1583669,"title":"The
         Secrets We Keep","year":2020,"imdb_id":"tt9252488","tmdb_id":615115,"tmdb_type":"movie","type":"movie"},{"id":1390975,"title":"The
@@ -541,13 +539,14 @@ http_interactions:
         Fine Day","year":1996,"imdb_id":"tt0117247","tmdb_id":7300,"tmdb_type":"movie","type":"movie"},{"id":1453880,"title":"Vampire
         in Brooklyn","year":1995,"imdb_id":"tt0114825","tmdb_id":12158,"tmdb_type":"movie","type":"movie"},{"id":1565138,"title":"Booksmart","year":2019,"imdb_id":"tt1489887","tmdb_id":505600,"tmdb_type":"movie","type":"movie"},{"id":1184309,"title":"Instant
         Family","year":2018,"imdb_id":"tt7401588","tmdb_id":491418,"tmdb_type":"movie","type":"movie"},{"id":168865,"title":"Catch
-        Me If You Can","year":2002,"imdb_id":"tt0264464","tmdb_id":640,"tmdb_type":"movie","type":"movie"},{"id":1585779,"title":"Blue
-        Story","year":2019,"imdb_id":"tt9285882","tmdb_id":621191,"tmdb_type":"movie","type":"movie"},{"id":1387475,"title":"The
+        Me If You Can","year":2002,"imdb_id":"tt0264464","tmdb_id":640,"tmdb_type":"movie","type":"movie"},{"id":1387475,"title":"The
         Devil''s Double","year":2011,"imdb_id":"tt1270262","tmdb_id":62630,"tmdb_type":"movie","type":"movie"},{"id":1162751,"title":"Hello
-        I Must Be Going","year":2012,"imdb_id":"tt2063666","tmdb_id":84281,"tmdb_type":"movie","type":"movie"},{"id":12809,"title":"28
-        Hotel Rooms","year":2012,"imdb_id":"tt2124074","tmdb_id":84166,"tmdb_type":"movie","type":"movie"},{"id":178814,"title":"Coherence","year":2013,"imdb_id":"tt2866360","tmdb_id":220289,"tmdb_type":"movie","type":"movie"},{"id":1231404,"title":"Little
-        Men","year":2016,"imdb_id":"tt4919484","tmdb_id":373473,"tmdb_type":"movie","type":"movie"},{"id":1440570,"title":"Triggered","year":2019,"imdb_id":"tt7126710","tmdb_id":554100,"tmdb_type":"movie","type":"movie"}],"page":2,"total_results":1994,"total_pages":8}'
-  recorded_at: Fri, 07 May 2021 03:02:07 GMT
+        I Must Be Going","year":2012,"imdb_id":"tt2063666","tmdb_id":84281,"tmdb_type":"movie","type":"movie"},{"id":178814,"title":"Coherence","year":2013,"imdb_id":"tt2866360","tmdb_id":220289,"tmdb_type":"movie","type":"movie"},{"id":12809,"title":"28
+        Hotel Rooms","year":2012,"imdb_id":"tt2124074","tmdb_id":84166,"tmdb_type":"movie","type":"movie"},{"id":1231404,"title":"Little
+        Men","year":2016,"imdb_id":"tt4919484","tmdb_id":373473,"tmdb_type":"movie","type":"movie"},{"id":1440570,"title":"Triggered","year":2019,"imdb_id":"tt7126710","tmdb_id":554100,"tmdb_type":"movie","type":"movie"},{"id":1582385,"title":"Missing
+        411: The Hunted","year":2019,"imdb_id":"tt10524262","tmdb_id":611444,"tmdb_type":"movie","type":"movie"},{"id":111693,"title":"A
+        Teacher","year":2013,"imdb_id":"tt2201548","tmdb_id":158884,"tmdb_type":"movie","type":"movie"}],"page":2,"total_results":1980,"total_pages":8}'
+  recorded_at: Sat, 08 May 2021 23:04:42 GMT
 - request:
     method: get
     uri: https://api.watchmode.com/v1/list-titles/?apiKey=<WATCHMODE_API_KEY>&page=3&regions=US&source_ids=157&source_types=sub&type=movie
@@ -567,7 +566,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 07 May 2021 03:02:07 GMT
+      - Sat, 08 May 2021 23:04:42 GMT
       Server:
       - Apache/2.4.46 (Ubuntu)
       Access-Control-Allow-Origin:
@@ -581,11 +580,11 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '118'
       Retry-After:
-      - '53'
+      - '18'
       X-Account-Quota:
       - '1000'
       X-Account-Quota-Used:
-      - '471'
+      - '479'
       Vary:
       - Accept-Encoding
       Transfer-Encoding:
@@ -594,10 +593,9 @@ http_interactions:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
-      string: '{"titles":[{"id":1582385,"title":"Missing 411: The Hunted","year":2019,"imdb_id":"tt10524262","tmdb_id":611444,"tmdb_type":"movie","type":"movie"},{"id":111693,"title":"A
-        Teacher","year":2013,"imdb_id":"tt2201548","tmdb_id":158884,"tmdb_type":"movie","type":"movie"},{"id":115147,"title":"Abominable","year":2019,"imdb_id":"tt6324278","tmdb_id":431580,"tmdb_type":"movie","type":"movie"},{"id":1577202,"title":"Pigeon
+      string: '{"titles":[{"id":115147,"title":"Abominable","year":2019,"imdb_id":"tt6324278","tmdb_id":431580,"tmdb_type":"movie","type":"movie"},{"id":1577202,"title":"Pigeon
         Kings","year":2020,"imdb_id":"tt3223318","tmdb_id":599506,"tmdb_type":"movie","type":"movie"},{"id":1590925,"title":"Cosmos","year":2019,"imdb_id":"tt4477292","tmdb_id":639771,"tmdb_type":"movie","type":"movie"},{"id":1187663,"title":"It''s
-        a Disaster","year":2012,"imdb_id":"tt1995341","tmdb_id":114779,"tmdb_type":"movie","type":"movie"},{"id":153865,"title":"Blame!","year":2017,"imdb_id":"tt6574146","tmdb_id":409421,"tmdb_type":"movie","type":"movie"},{"id":196104,"title":"Delirium","year":2018,"imdb_id":"tt3131050","tmdb_id":401732,"tmdb_type":"movie","type":"movie"},{"id":196102,"title":"Delirium","year":2018,"imdb_id":"tt2069797","tmdb_id":340601,"tmdb_type":"movie","type":"movie"},{"id":1105599,"title":"Dismissed","year":2017,"imdb_id":"tt5039994","tmdb_id":398588,"tmdb_type":"movie","type":"movie"},{"id":175147,"title":"Christine","year":2016,"imdb_id":"tt4666726","tmdb_id":339405,"tmdb_type":"movie","type":"movie"},{"id":1251422,"title":"Melancholia","year":2011,"imdb_id":"tt1527186","tmdb_id":62215,"tmdb_type":"movie","type":"movie"},{"id":159946,"title":"Breakup
+        a Disaster","year":2012,"imdb_id":"tt1995341","tmdb_id":114779,"tmdb_type":"movie","type":"movie"},{"id":196104,"title":"Delirium","year":2018,"imdb_id":"tt3131050","tmdb_id":401732,"tmdb_type":"movie","type":"movie"},{"id":196102,"title":"Delirium","year":2018,"imdb_id":"tt2069797","tmdb_id":340601,"tmdb_type":"movie","type":"movie"},{"id":1105599,"title":"Dismissed","year":2017,"imdb_id":"tt5039994","tmdb_id":398588,"tmdb_type":"movie","type":"movie"},{"id":175147,"title":"Christine","year":2016,"imdb_id":"tt4666726","tmdb_id":339405,"tmdb_type":"movie","type":"movie"},{"id":1251422,"title":"Melancholia","year":2011,"imdb_id":"tt1527186","tmdb_id":62215,"tmdb_type":"movie","type":"movie"},{"id":159946,"title":"Breakup
         at a Wedding","year":2013,"imdb_id":"tt1935300","tmdb_id":201772,"tmdb_type":"movie","type":"movie"},{"id":1353561,"title":"Sollers
         Point","year":2017,"imdb_id":"tt5180888","tmdb_id":430450,"tmdb_type":"movie","type":"movie"},{"id":1588704,"title":"5
         Years Apart","year":2019,"imdb_id":"tt7736968","tmdb_id":631290,"tmdb_type":"movie","type":"movie"},{"id":1407363,"title":"The
@@ -607,10 +605,10 @@ http_interactions:
         and Kicking","year":2016,"imdb_id":"tt4329394","tmdb_id":381020,"tmdb_type":"movie","type":"movie"},{"id":1506248,"title":"Running
         with the Devil","year":2019,"imdb_id":"tt5792656","tmdb_id":523077,"tmdb_type":"movie","type":"movie"},{"id":1575849,"title":"Bull","year":2019,"imdb_id":"tt10008784","tmdb_id":595940,"tmdb_type":"movie","type":"movie"},{"id":147463,"title":"Ben
         Is Back","year":2018,"imdb_id":"tt7545524","tmdb_id":492452,"tmdb_type":"movie","type":"movie"},{"id":1211191,"title":"L!fe
-        Happens","year":2011,"imdb_id":"tt1726589","tmdb_id":91070,"tmdb_type":"movie","type":"movie"},{"id":1594349,"title":"The
-        Painter and the Thief","year":2020,"imdb_id":"tt11296058","tmdb_id":654170,"tmdb_type":"movie","type":"movie"},{"id":1610041,"title":"Spaceship
+        Happens","year":2011,"imdb_id":"tt1726589","tmdb_id":91070,"tmdb_type":"movie","type":"movie"},{"id":1610041,"title":"Spaceship
         Earth","year":2020,"imdb_id":"tt11394188","tmdb_id":653575,"tmdb_type":"movie","type":"movie"},{"id":1591490,"title":"Trauma
-        Center","year":2019,"imdb_id":"tt9625664","tmdb_id":641790,"tmdb_type":"movie","type":"movie"},{"id":1599604,"title":"You
+        Center","year":2019,"imdb_id":"tt9625664","tmdb_id":641790,"tmdb_type":"movie","type":"movie"},{"id":1594349,"title":"The
+        Painter and the Thief","year":2020,"imdb_id":"tt11296058","tmdb_id":654170,"tmdb_type":"movie","type":"movie"},{"id":1599604,"title":"You
         Cannot Kill David Arquette","year":2020,"imdb_id":"tt11454066","tmdb_id":672035,"tmdb_type":"movie","type":"movie"},{"id":1514724,"title":"Sea
         of Shadows","year":2019,"imdb_id":"tt9326056","tmdb_id":566219,"tmdb_type":"movie","type":"movie"},{"id":1233883,"title":"Lords
         of Chaos","year":2018,"imdb_id":"tt4669296","tmdb_id":426249,"tmdb_type":"movie","type":"movie"},{"id":140381,"title":"Backtrace","year":2018,"imdb_id":"tt3588588","tmdb_id":512412,"tmdb_type":"movie","type":"movie"},{"id":162270,"title":"Buffaloed","year":2019,"imdb_id":"tt8647310","tmdb_id":547012,"tmdb_type":"movie","type":"movie"},{"id":1238045,"title":"Luce","year":2019,"imdb_id":"tt7616148","tmdb_id":492616,"tmdb_type":"movie","type":"movie"},{"id":1613032,"title":"Mighty
@@ -656,13 +654,13 @@ http_interactions:
         Great Debaters","year":2007,"imdb_id":"tt0427309","tmdb_id":14047,"tmdb_type":"movie","type":"movie"},{"id":1418882,"title":"The
         Shock Doctrine","year":2009,"imdb_id":"tt1355640","tmdb_id":41116,"tmdb_type":"movie","type":"movie"},{"id":168030,"title":"Carrington","year":1995,"imdb_id":"tt0112637","tmdb_id":47018,"tmdb_type":"movie","type":"movie"},{"id":1550100,"title":"Framing
         John DeLorean","year":2019,"imdb_id":"tt6256978","tmdb_id":544003,"tmdb_type":"movie","type":"movie"},{"id":196973,"title":"Depraved","year":2019,"imdb_id":"tt7946216","tmdb_id":501977,"tmdb_type":"movie","type":"movie"},{"id":1247225,"title":"Spy
-        Cat","year":2018,"imdb_id":"tt5746054","tmdb_id":509733,"tmdb_type":"movie","type":"movie"},{"id":1299565,"title":"Person
-        to Person","year":2017,"imdb_id":"tt5247026","tmdb_id":386623,"tmdb_type":"movie","type":"movie"},{"id":1325184,"title":"Roller
+        Cat","year":2018,"imdb_id":"tt5746054","tmdb_id":509733,"tmdb_type":"movie","type":"movie"},{"id":1325184,"title":"Roller
         Dreams","year":2017,"imdb_id":"tt1887852","tmdb_id":449458,"tmdb_type":"movie","type":"movie"},{"id":1328258,"title":"Rustlers''
         Rhapsody","year":1985,"imdb_id":"tt0089945","tmdb_id":19014,"tmdb_type":"movie","type":"movie"},{"id":1369766,"title":"Take
         My Nose... Please!","year":2017,"imdb_id":"tt4310428","tmdb_id":479552,"tmdb_type":"movie","type":"movie"},{"id":1513056,"title":"David
         Crosby: Remember My Name","year":2019,"imdb_id":"tt5884004","tmdb_id":565718,"tmdb_type":"movie","type":"movie"},{"id":1556521,"title":"The
-        Brink","year":2019,"imdb_id":"tt9600932","tmdb_id":576334,"tmdb_type":"movie","type":"movie"},{"id":1568402,"title":"StarDog
+        Brink","year":2019,"imdb_id":"tt9600932","tmdb_id":576334,"tmdb_type":"movie","type":"movie"},{"id":1562951,"title":"Body
+        at Brighton Rock","year":2019,"imdb_id":"tt7942746","tmdb_id":555295,"tmdb_type":"movie","type":"movie"},{"id":1568402,"title":"StarDog
         and TurboCat","year":2019,"imdb_id":"tt7531096","tmdb_id":515789,"tmdb_type":"movie","type":"movie"},{"id":1578379,"title":"Adam","year":2019,"imdb_id":"tt10199664","tmdb_id":595875,"tmdb_type":"movie","type":"movie"},{"id":1610217,"title":"Ottolenghi
         and the Cakes of Versailles","year":2020,"imdb_id":"tt11656800","tmdb_id":698305,"tmdb_type":"movie","type":"movie"},{"id":1465188,"title":"Wetlands","year":2019,"imdb_id":"tt5565254","tmdb_id":474170,"tmdb_type":"movie","type":"movie"},{"id":1206485,"title":"Knights
         of the Damned","year":2017,"imdb_id":"tt5931670","tmdb_id":464876,"tmdb_type":"movie","type":"movie"},{"id":1249828,"title":"Maze","year":2017,"imdb_id":"tt5752606","tmdb_id":464566,"tmdb_type":"movie","type":"movie"},{"id":1367548,"title":"Swimming
@@ -679,8 +677,7 @@ http_interactions:
         Tenant","year":1976,"imdb_id":"tt0074811","tmdb_id":11482,"tmdb_type":"movie","type":"movie"},{"id":1235419,"title":"Lost
         in London","year":2017,"imdb_id":"tt6338476","tmdb_id":435218,"tmdb_type":"movie","type":"movie"},{"id":11857,"title":"1900","year":1976,"imdb_id":"tt0074084","tmdb_id":3870,"tmdb_type":"movie","type":"movie"},{"id":1114520,"title":"Eating
         Animals","year":2017,"imdb_id":"tt2180351","tmdb_id":503150,"tmdb_type":"movie","type":"movie"},{"id":1308142,"title":"Princess
-        Cyd","year":2017,"imdb_id":"tt6053440","tmdb_id":454889,"tmdb_type":"movie","type":"movie"},{"id":1290643,"title":"Our
-        Family Wedding","year":2010,"imdb_id":"tt1305583","tmdb_id":34563,"tmdb_type":"movie","type":"movie"},{"id":1402129,"title":"The
+        Cyd","year":2017,"imdb_id":"tt6053440","tmdb_id":454889,"tmdb_type":"movie","type":"movie"},{"id":1402129,"title":"The
         Last Stand","year":2013,"imdb_id":"tt1549920","tmdb_id":76640,"tmdb_type":"movie","type":"movie"},{"id":1384204,"title":"The
         Color Purple","year":1985,"imdb_id":"tt0088939","tmdb_id":873,"tmdb_type":"movie","type":"movie"},{"id":1421491,"title":"The
         Strange Ones","year":2017,"imdb_id":"tt6014904","tmdb_id":426258,"tmdb_type":"movie","type":"movie"},{"id":190226,"title":"Dark
@@ -753,9 +750,9 @@ http_interactions:
         Cover","year":2017,"imdb_id":"tt3457508","tmdb_id":324538,"tmdb_type":"movie","type":"movie"},{"id":1170475,"title":"Hounds
         of Love","year":2016,"imdb_id":"tt3896738","tmdb_id":408439,"tmdb_type":"movie","type":"movie"},{"id":1176519,"title":"I.T.","year":2016,"imdb_id":"tt2679552","tmdb_id":340677,"tmdb_type":"movie","type":"movie"},{"id":1194220,"title":"Josie","year":2018,"imdb_id":"tt4682780","tmdb_id":414187,"tmdb_type":"movie","type":"movie"},{"id":1275296,"title":"Nina","year":2016,"imdb_id":"tt0493076","tmdb_id":360389,"tmdb_type":"movie","type":"movie"},{"id":1322369,"title":"Ride","year":2018,"imdb_id":"tt6237268","tmdb_id":542905,"tmdb_type":"movie","type":"movie"},{"id":1587887,"title":"Trick","year":2019,"imdb_id":"tt9177040","tmdb_id":628707,"tmdb_type":"movie","type":"movie"},{"id":161493,"title":"Brown
         Girl Begins","year":2017,"imdb_id":"tt5240730","tmdb_id":501098,"tmdb_type":"movie","type":"movie"},{"id":1379003,"title":"The
-        Bellboy","year":1960,"imdb_id":"tt0053644","tmdb_id":15788,"tmdb_type":"movie","type":"movie"},{"id":1420202,"title":"The
+        Bellboy","year":1960,"imdb_id":"tt0053644","tmdb_id":15788,"tmdb_type":"movie","type":"movie"},{"id":158564,"title":"Bound","year":1996,"imdb_id":"tt0115736","tmdb_id":9303,"tmdb_type":"movie","type":"movie"},{"id":1420202,"title":"The
         Sons of Katie Elder","year":1965,"imdb_id":"tt0059740","tmdb_id":16211,"tmdb_type":"movie","type":"movie"},{"id":1415304,"title":"The
-        Relic","year":1997,"imdb_id":"tt0120004","tmdb_id":11015,"tmdb_type":"movie","type":"movie"},{"id":158564,"title":"Bound","year":1996,"imdb_id":"tt0115736","tmdb_id":9303,"tmdb_type":"movie","type":"movie"},{"id":176308,"title":"Cinderfella","year":1960,"imdb_id":"tt0053716","tmdb_id":18973,"tmdb_type":"movie","type":"movie"},{"id":1344533,"title":"Shine
+        Relic","year":1997,"imdb_id":"tt0120004","tmdb_id":11015,"tmdb_type":"movie","type":"movie"},{"id":176308,"title":"Cinderfella","year":1960,"imdb_id":"tt0053716","tmdb_id":18973,"tmdb_type":"movie","type":"movie"},{"id":1344533,"title":"Shine
         a Light","year":2008,"imdb_id":"tt0893382","tmdb_id":7944,"tmdb_type":"movie","type":"movie"},{"id":1100027,"title":"Detective
         Dee: The Four Heavenly Kings","year":2018,"imdb_id":"tt6869538","tmdb_id":506763,"tmdb_type":"movie","type":"movie"},{"id":1532000,"title":"Hail
         Satan?","year":2019,"imdb_id":"tt9358044","tmdb_id":565719,"tmdb_type":"movie","type":"movie"},{"id":1568914,"title":"Divide
@@ -784,8 +781,11 @@ http_interactions:
         Sherlock Holmes","year":1985,"imdb_id":"tt0090357","tmdb_id":11904,"tmdb_type":"movie","type":"movie"},{"id":1229516,"title":"Life
         of Crime","year":2013,"imdb_id":"tt1663207","tmdb_id":209189,"tmdb_type":"movie","type":"movie"},{"id":1615480,"title":"Skin:
         A History of Nudity in the Movies","year":2020,"imdb_id":"tt11245776","tmdb_id":722926,"tmdb_type":"movie","type":"movie"},{"id":1617669,"title":"Then
-        Came You","year":2020,"imdb_id":"tt8367084","tmdb_id":743283,"tmdb_type":"movie","type":"movie"}],"page":3,"total_results":1994,"total_pages":8}'
-  recorded_at: Fri, 07 May 2021 03:02:07 GMT
+        Came You","year":2020,"imdb_id":"tt8367084","tmdb_id":743283,"tmdb_type":"movie","type":"movie"},{"id":1479029,"title":"Zappa","year":2020,"imdb_id":"tt4881578","tmdb_id":353047,"tmdb_type":"movie","type":"movie"},{"id":1257216,"title":"Mission:
+        Impossible - Ghost Protocol","year":2011,"imdb_id":"tt1229238","tmdb_id":56292,"tmdb_type":"movie","type":"movie"},{"id":1402564,"title":"The
+        Layover","year":2017,"imdb_id":"tt4565520","tmdb_id":339404,"tmdb_type":"movie","type":"movie"},{"id":1422684,"title":"The
+        Tax Collector","year":2020,"imdb_id":"tt8461224","tmdb_id":531499,"tmdb_type":"movie","type":"movie"}],"page":3,"total_results":1980,"total_pages":8}'
+  recorded_at: Sat, 08 May 2021 23:04:42 GMT
 - request:
     method: get
     uri: https://api.watchmode.com/v1/list-titles/?apiKey=<WATCHMODE_API_KEY>&page=4&regions=US&source_ids=157&source_types=sub&type=movie
@@ -805,7 +805,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 07 May 2021 03:02:08 GMT
+      - Sat, 08 May 2021 23:04:42 GMT
       Server:
       - Apache/2.4.46 (Ubuntu)
       Access-Control-Allow-Origin:
@@ -819,11 +819,11 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '117'
       Retry-After:
-      - '52'
+      - '18'
       X-Account-Quota:
       - '1000'
       X-Account-Quota-Used:
-      - '472'
+      - '480'
       Vary:
       - Accept-Encoding
       Transfer-Encoding:
@@ -832,11 +832,7 @@ http_interactions:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
-      string: '{"titles":[{"id":1479029,"title":"Zappa","year":2020,"imdb_id":"tt4881578","tmdb_id":353047,"tmdb_type":"movie","type":"movie"},{"id":1257216,"title":"Mission:
-        Impossible - Ghost Protocol","year":2011,"imdb_id":"tt1229238","tmdb_id":56292,"tmdb_type":"movie","type":"movie"},{"id":1402564,"title":"The
-        Layover","year":2017,"imdb_id":"tt4565520","tmdb_id":339404,"tmdb_type":"movie","type":"movie"},{"id":1422684,"title":"The
-        Tax Collector","year":2020,"imdb_id":"tt8461224","tmdb_id":531499,"tmdb_type":"movie","type":"movie"},{"id":1425211,"title":"The
-        Unicorn","year":2018,"imdb_id":"tt7149336","tmdb_id":483351,"tmdb_type":"movie","type":"movie"},{"id":1158736,"title":"Happy
+      string: '{"titles":[{"id":1425211,"title":"The Unicorn","year":2018,"imdb_id":"tt7149336","tmdb_id":483351,"tmdb_type":"movie","type":"movie"},{"id":1158736,"title":"Happy
         Tears","year":2009,"imdb_id":"tt1219828","tmdb_id":39072,"tmdb_type":"movie","type":"movie"},{"id":1330321,"title":"Sahara","year":1983,"imdb_id":"tt0086232","tmdb_id":47808,"tmdb_type":"movie","type":"movie"},{"id":1419010,"title":"The
         Shrine","year":2010,"imdb_id":"tt1341710","tmdb_id":47763,"tmdb_type":"movie","type":"movie"},{"id":1127817,"title":"Eye
         in the Sky","year":2015,"imdb_id":"tt2057392","tmdb_id":333352,"tmdb_type":"movie","type":"movie"},{"id":1248673,"title":"Match","year":2014,"imdb_id":"tt2637378","tmdb_id":261036,"tmdb_type":"movie","type":"movie"},{"id":1303956,"title":"Pok\u00e9mon
@@ -896,7 +892,7 @@ http_interactions:
         My Name Is Doris","year":2015,"imdb_id":"tt3766394","tmdb_id":320588,"tmdb_type":"movie","type":"movie"},{"id":1356327,"title":"Southside
         with You","year":2016,"imdb_id":"tt4258698","tmdb_id":310888,"tmdb_type":"movie","type":"movie"},{"id":1112123,"title":"Dude,
         Where''s My Car?","year":2000,"imdb_id":"tt0242423","tmdb_id":8859,"tmdb_type":"movie","type":"movie"},{"id":1171086,"title":"How
-        Stella Got Her Groove Back","year":1998,"imdb_id":"tt0120703","tmdb_id":33644,"tmdb_type":"movie","type":"movie"},{"id":1579983,"title":"Supervized","year":2019,"imdb_id":"tt7302054","tmdb_id":605048,"tmdb_type":"movie","type":"movie"},{"id":1177201,"title":"Identity","year":2003,"imdb_id":"tt0309698","tmdb_id":2832,"tmdb_type":"movie","type":"movie"},{"id":1230001,"title":"Lights
+        Stella Got Her Groove Back","year":1998,"imdb_id":"tt0120703","tmdb_id":33644,"tmdb_type":"movie","type":"movie"},{"id":1177201,"title":"Identity","year":2003,"imdb_id":"tt0309698","tmdb_id":2832,"tmdb_type":"movie","type":"movie"},{"id":1230001,"title":"Lights
         Out","year":2016,"imdb_id":"tt4786282","tmdb_id":345911,"tmdb_type":"movie","type":"movie"},{"id":1293733,"title":"Pan","year":2015,"imdb_id":"tt3332064","tmdb_id":266647,"tmdb_type":"movie","type":"movie"},{"id":1601415,"title":"Shadow
         in the Cloud","year":2020,"imdb_id":"tt9691136","tmdb_id":675327,"tmdb_type":"movie","type":"movie"},{"id":1259764,"title":"Monster''s
         Ball","year":2001,"imdb_id":"tt0285742","tmdb_id":1365,"tmdb_type":"movie","type":"movie"},{"id":1370951,"title":"Tank
@@ -930,10 +926,12 @@ http_interactions:
         the Tree","year":2017,"imdb_id":"tt6223806","tmdb_id":472640,"tmdb_type":"movie","type":"movie"},{"id":1393462,"title":"The
         Ghost Writer","year":2010,"imdb_id":"tt1139328","tmdb_id":11439,"tmdb_type":"movie","type":"movie"},{"id":1594121,"title":"Save
         Yourselves!","year":2020,"imdb_id":"tt7873348","tmdb_id":653569,"tmdb_type":"movie","type":"movie"},{"id":1587609,"title":"The
-        Assistant","year":2019,"imdb_id":"tt9000224","tmdb_id":627463,"tmdb_type":"movie","type":"movie"},{"id":1353273,"title":"Sold","year":2014,"imdb_id":"tt1411956","tmdb_id":257258,"tmdb_type":"movie","type":"movie"},{"id":1391534,"title":"The
+        Assistant","year":2019,"imdb_id":"tt9000224","tmdb_id":627463,"tmdb_type":"movie","type":"movie"},{"id":1172649,"title":"Hunt
+        for the Wilderpeople","year":2016,"imdb_id":"tt4698684","tmdb_id":371645,"tmdb_type":"movie","type":"movie"},{"id":1353273,"title":"Sold","year":2014,"imdb_id":"tt1411956","tmdb_id":257258,"tmdb_type":"movie","type":"movie"},{"id":1391534,"title":"The
         First Monday in May","year":2016,"imdb_id":"tt5519566","tmdb_id":384573,"tmdb_type":"movie","type":"movie"},{"id":1104374,"title":"Digging
         for Fire","year":2015,"imdb_id":"tt3704416","tmdb_id":295490,"tmdb_type":"movie","type":"movie"},{"id":1165352,"title":"High-Rise","year":2015,"imdb_id":"tt0462335","tmdb_id":254302,"tmdb_type":"movie","type":"movie"},{"id":1163156,"title":"Henry
-        Gamble''s Birthday Party","year":2015,"imdb_id":"tt3703836","tmdb_id":339739,"tmdb_type":"movie","type":"movie"},{"id":11003,"title":"100
+        Gamble''s Birthday Party","year":2015,"imdb_id":"tt3703836","tmdb_id":339739,"tmdb_type":"movie","type":"movie"},{"id":1137540,"title":"Force
+        Majeure","year":2014,"imdb_id":"tt2121382","tmdb_id":265189,"tmdb_type":"movie","type":"movie"},{"id":11003,"title":"100
         Streets","year":2016,"imdb_id":"tt2990126","tmdb_id":334532,"tmdb_type":"movie","type":"movie"},{"id":1265648,"title":"My
         Friend Dahmer","year":2017,"imdb_id":"tt2291540","tmdb_id":445040,"tmdb_type":"movie","type":"movie"},{"id":115297,"title":"Above
         and Beyond","year":2014,"imdb_id":"tt2704752","tmdb_id":315839,"tmdb_type":"movie","type":"movie"},{"id":16432,"title":"A
@@ -956,8 +954,7 @@ http_interactions:
         Noah: You Laugh But It''s True","year":2011,"imdb_id":"tt1671547","tmdb_id":169721,"tmdb_type":"movie","type":"movie"},{"id":1357580,"title":"Spirit:
         Stallion of the Cimarron","year":2002,"imdb_id":"tt0166813","tmdb_id":9023,"tmdb_type":"movie","type":"movie"},{"id":1417972,"title":"The
         Secret Life of Bees","year":2008,"imdb_id":"tt0416212","tmdb_id":12837,"tmdb_type":"movie","type":"movie"},{"id":13912,"title":"4th
-        Man Out","year":2015,"imdb_id":"tt3978720","tmdb_id":342672,"tmdb_type":"movie","type":"movie"},{"id":122696,"title":"All
-        Summers End","year":2017,"imdb_id":"tt2370230","tmdb_id":322517,"tmdb_type":"movie","type":"movie"},{"id":155689,"title":"Blue
+        Man Out","year":2015,"imdb_id":"tt3978720","tmdb_id":342672,"tmdb_type":"movie","type":"movie"},{"id":155689,"title":"Blue
         Chips","year":1994,"imdb_id":"tt0109305","tmdb_id":19819,"tmdb_type":"movie","type":"movie"},{"id":1149288,"title":"Gloves
         Off","year":2017,"imdb_id":"tt4851570","tmdb_id":477794,"tmdb_type":"movie","type":"movie"},{"id":1409974,"title":"The
         November Man","year":2014,"imdb_id":"tt2402157","tmdb_id":254904,"tmdb_type":"movie","type":"movie"},{"id":1426150,"title":"The
@@ -975,8 +972,7 @@ http_interactions:
         Were Soldiers","year":2002,"imdb_id":"tt0277434","tmdb_id":10590,"tmdb_type":"movie","type":"movie"},{"id":1204173,"title":"Killer
         Joe","year":2011,"imdb_id":"tt1726669","tmdb_id":73567,"tmdb_type":"movie","type":"movie"},{"id":1406952,"title":"The
         Mechanic","year":1972,"imdb_id":"tt0068931","tmdb_id":19403,"tmdb_type":"movie","type":"movie"},{"id":171178,"title":"Chaplin","year":1992,"imdb_id":"tt0103939","tmdb_id":10435,"tmdb_type":"movie","type":"movie"},{"id":1332484,"title":"Sands
-        of Iwo Jima","year":1949,"imdb_id":"tt0041841","tmdb_id":18712,"tmdb_type":"movie","type":"movie"},{"id":1385212,"title":"The
-        Crazies","year":2010,"imdb_id":"tt0455407","tmdb_id":29427,"tmdb_type":"movie","type":"movie"},{"id":161213,"title":"Brooklyn''s
+        of Iwo Jima","year":1949,"imdb_id":"tt0041841","tmdb_id":18712,"tmdb_type":"movie","type":"movie"},{"id":161213,"title":"Brooklyn''s
         Finest","year":2009,"imdb_id":"tt1210042","tmdb_id":26390,"tmdb_type":"movie","type":"movie"},{"id":1168734,"title":"Hondo","year":1953,"imdb_id":"tt0045883","tmdb_id":6529,"tmdb_type":"movie","type":"movie"},{"id":1142014,"title":"Fun
         in Acapulco","year":1963,"imdb_id":"tt0057083","tmdb_id":18692,"tmdb_type":"movie","type":"movie"},{"id":1618148,"title":"Knuckledust","year":2020,"imdb_id":"tt9109072","tmdb_id":749407,"tmdb_type":"movie","type":"movie"},{"id":1471310,"title":"Woman
         at War","year":2018,"imdb_id":"tt7279188","tmdb_id":348657,"tmdb_type":"movie","type":"movie"},{"id":1176462,"title":"I,
@@ -1002,8 +998,7 @@ http_interactions:
         Tuxedo","year":2002,"imdb_id":"tt0290095","tmdb_id":10771,"tmdb_type":"movie","type":"movie"},{"id":1584673,"title":"Once
         Were Brothers: Robbie Robertson and The Band","year":2019,"imdb_id":"tt10334456","tmdb_id":617771,"tmdb_type":"movie","type":"movie"},{"id":1250000,"title":"McQueen","year":2018,"imdb_id":"tt6510332","tmdb_id":508003,"tmdb_type":"movie","type":"movie"},{"id":1514738,"title":"The
         Kid","year":2019,"imdb_id":"tt4975920","tmdb_id":492565,"tmdb_type":"movie","type":"movie"},{"id":1405878,"title":"The
-        Man Who Killed Hitler and Then the Bigfoot","year":2018,"imdb_id":"tt7042862","tmdb_id":530081,"tmdb_type":"movie","type":"movie"},{"id":1562951,"title":"Body
-        at Brighton Rock","year":2019,"imdb_id":"tt7942746","tmdb_id":555295,"tmdb_type":"movie","type":"movie"},{"id":1291854,"title":"Overdrive","year":2017,"imdb_id":"tt1935194","tmdb_id":404733,"tmdb_type":"movie","type":"movie"},{"id":1374038,"title":"Terminal","year":2018,"imdb_id":"tt4463816","tmdb_id":385332,"tmdb_type":"movie","type":"movie"},{"id":1399351,"title":"The
+        Man Who Killed Hitler and Then the Bigfoot","year":2018,"imdb_id":"tt7042862","tmdb_id":530081,"tmdb_type":"movie","type":"movie"},{"id":1291854,"title":"Overdrive","year":2017,"imdb_id":"tt1935194","tmdb_id":404733,"tmdb_type":"movie","type":"movie"},{"id":1374038,"title":"Terminal","year":2018,"imdb_id":"tt4463816","tmdb_id":385332,"tmdb_type":"movie","type":"movie"},{"id":1399351,"title":"The
         Iron Lady","year":2011,"imdb_id":"tt1007029","tmdb_id":71688,"tmdb_type":"movie","type":"movie"},{"id":1421902,"title":"The
         Sum of All Fears","year":2002,"imdb_id":"tt0164184","tmdb_id":4614,"tmdb_type":"movie","type":"movie"},{"id":1184577,"title":"Internal
         Affairs","year":1990,"imdb_id":"tt0099850","tmdb_id":11060,"tmdb_type":"movie","type":"movie"},{"id":1441039,"title":"Trolls
@@ -1016,7 +1011,8 @@ http_interactions:
         Family Stone","year":2005,"imdb_id":"tt0356680","tmdb_id":9043,"tmdb_type":"movie","type":"movie"},{"id":1250648,"title":"Meek''s
         Cutoff","year":2010,"imdb_id":"tt1518812","tmdb_id":57120,"tmdb_type":"movie","type":"movie"},{"id":1275552,"title":"Ninja
         Scroll","year":1993,"imdb_id":"tt0107692","tmdb_id":14282,"tmdb_type":"movie","type":"movie"},{"id":113710,"title":"AWOL","year":2016,"imdb_id":"tt4462372","tmdb_id":356752,"tmdb_type":"movie","type":"movie"},{"id":1195989,"title":"Just
-        Eat It: A Food Waste Story","year":2014,"imdb_id":"tt3597400","tmdb_id":259985,"tmdb_type":"movie","type":"movie"},{"id":1387124,"title":"The
+        Eat It: A Food Waste Story","year":2014,"imdb_id":"tt3597400","tmdb_id":259985,"tmdb_type":"movie","type":"movie"},{"id":1385212,"title":"The
+        Crazies","year":2010,"imdb_id":"tt0455407","tmdb_id":29427,"tmdb_type":"movie","type":"movie"},{"id":1387124,"title":"The
         Descent","year":2005,"imdb_id":"tt0435625","tmdb_id":9392,"tmdb_type":"movie","type":"movie"},{"id":1356242,"title":"Southbound","year":2015,"imdb_id":"tt4935334","tmdb_id":354251,"tmdb_type":"movie","type":"movie"},{"id":1386655,"title":"The
         Dead Zone","year":1983,"imdb_id":"tt0085407","tmdb_id":11336,"tmdb_type":"movie","type":"movie"},{"id":1148166,"title":"Girl
         Most Likely","year":2012,"imdb_id":"tt1698648","tmdb_id":72890,"tmdb_type":"movie","type":"movie"},{"id":1361297,"title":"Storks","year":2016,"imdb_id":"tt4624424","tmdb_id":332210,"tmdb_type":"movie","type":"movie"},{"id":1565257,"title":"General
@@ -1028,8 +1024,12 @@ http_interactions:
         Expendables 3","year":2014,"imdb_id":"tt2333784","tmdb_id":138103,"tmdb_type":"movie","type":"movie"},{"id":1463330,"title":"We
         Die Young","year":2019,"imdb_id":"tt7903530","tmdb_id":538207,"tmdb_type":"movie","type":"movie"},{"id":1130477,"title":"Fast
         Color","year":2018,"imdb_id":"tt6418778","tmdb_id":450487,"tmdb_type":"movie","type":"movie"},{"id":1405877,"title":"The
-        Man Who Killed Don Quixote","year":2018,"imdb_id":"tt1318517","tmdb_id":297725,"tmdb_type":"movie","type":"movie"}],"page":4,"total_results":1994,"total_pages":8}'
-  recorded_at: Fri, 07 May 2021 03:02:08 GMT
+        Man Who Killed Don Quixote","year":2018,"imdb_id":"tt1318517","tmdb_id":297725,"tmdb_type":"movie","type":"movie"},{"id":182427,"title":"Corporate
+        Animals","year":2019,"imdb_id":"tt8366502","tmdb_id":530076,"tmdb_type":"movie","type":"movie"},{"id":1506250,"title":"Grand
+        Isle","year":2019,"imdb_id":"tt8380776","tmdb_id":560192,"tmdb_type":"movie","type":"movie"},{"id":185027,"title":"Crown
+        Vic","year":2019,"imdb_id":"tt4558200","tmdb_id":524659,"tmdb_type":"movie","type":"movie"},{"id":162283,"title":"Bug","year":1975,"imdb_id":"tt0072750","tmdb_id":62697,"tmdb_type":"movie","type":"movie"},{"id":1463466,"title":"We
+        Need to Talk About Kevin","year":2011,"imdb_id":"tt1242460","tmdb_id":71859,"tmdb_type":"movie","type":"movie"}],"page":4,"total_results":1980,"total_pages":8}'
+  recorded_at: Sat, 08 May 2021 23:04:43 GMT
 - request:
     method: get
     uri: https://api.watchmode.com/v1/list-titles/?apiKey=<WATCHMODE_API_KEY>&page=5&regions=US&source_ids=157&source_types=sub&type=movie
@@ -1049,7 +1049,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 07 May 2021 03:02:08 GMT
+      - Sat, 08 May 2021 23:04:43 GMT
       Server:
       - Apache/2.4.46 (Ubuntu)
       Access-Control-Allow-Origin:
@@ -1063,11 +1063,11 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '116'
       Retry-After:
-      - '52'
+      - '17'
       X-Account-Quota:
       - '1000'
       X-Account-Quota-Used:
-      - '473'
+      - '481'
       Vary:
       - Accept-Encoding
       Transfer-Encoding:
@@ -1076,10 +1076,7 @@ http_interactions:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
-      string: '{"titles":[{"id":182427,"title":"Corporate Animals","year":2019,"imdb_id":"tt8366502","tmdb_id":530076,"tmdb_type":"movie","type":"movie"},{"id":1506250,"title":"Grand
-        Isle","year":2019,"imdb_id":"tt8380776","tmdb_id":560192,"tmdb_type":"movie","type":"movie"},{"id":185027,"title":"Crown
-        Vic","year":2019,"imdb_id":"tt4558200","tmdb_id":524659,"tmdb_type":"movie","type":"movie"},{"id":162283,"title":"Bug","year":1975,"imdb_id":"tt0072750","tmdb_id":62697,"tmdb_type":"movie","type":"movie"},{"id":1463466,"title":"We
-        Need to Talk About Kevin","year":2011,"imdb_id":"tt1242460","tmdb_id":71859,"tmdb_type":"movie","type":"movie"},{"id":1259544,"title":"Monogamy","year":2010,"imdb_id":"tt1502714","tmdb_id":55895,"tmdb_type":"movie","type":"movie"},{"id":1342602,"title":"Shangri-La
+      string: '{"titles":[{"id":1259544,"title":"Monogamy","year":2010,"imdb_id":"tt1502714","tmdb_id":55895,"tmdb_type":"movie","type":"movie"},{"id":1342602,"title":"Shangri-La
         Suite","year":2016,"imdb_id":"tt3014078","tmdb_id":322548,"tmdb_type":"movie","type":"movie"},{"id":124024,"title":"Already
         Tomorrow in Hong Kong","year":2015,"imdb_id":"tt3700804","tmdb_id":339148,"tmdb_type":"movie","type":"movie"},{"id":1426431,"title":"The
         Wailing","year":2016,"imdb_id":"tt5215952","tmdb_id":293670,"tmdb_type":"movie","type":"movie"},{"id":18304,"title":"A
@@ -1096,8 +1093,7 @@ http_interactions:
         Housewife","year":2016,"imdb_id":"tt5396394","tmdb_id":67117,"tmdb_type":"tv","type":"tv_series"},{"id":348921,"title":"Grey''s
         Anatomy","year":2005,"imdb_id":"tt0413573","tmdb_id":1416,"tmdb_type":"tv","type":"tv_series"},{"id":341351,"title":"Felicity","year":1998,"imdb_id":"tt0134247","tmdb_id":2822,"tmdb_type":"tv","type":"tv_series"},{"id":3111780,"title":"Station
         19","year":2018,"imdb_id":"tt7053188","tmdb_id":76773,"tmdb_type":"tv","type":"tv_series"},{"id":3120871,"title":"The
-        Cool Kids","year":2018,"imdb_id":"tt7725538","tmdb_id":79723,"tmdb_type":"tv","type":"tv_series"},{"id":32002,"title":"9-1-1","year":2018,"imdb_id":"tt7235466","tmdb_id":75219,"tmdb_type":"tv","type":"tv_series"},{"id":3129170,"title":"The
-        Simpsons","year":1989,"imdb_id":"tt0096697","tmdb_id":456,"tmdb_type":"tv","type":"tv_series"},{"id":3164533,"title":"The
+        Cool Kids","year":2018,"imdb_id":"tt7725538","tmdb_id":79723,"tmdb_type":"tv","type":"tv_series"},{"id":32002,"title":"9-1-1","year":2018,"imdb_id":"tt7235466","tmdb_id":75219,"tmdb_type":"tv","type":"tv_series"},{"id":3164533,"title":"The
         Great North","year":2021,"imdb_id":"tt9140632","tmdb_id":93221,"tmdb_type":"tv","type":"tv_series"},{"id":3162870,"title":"NEXT","year":2020,"imdb_id":"tt9315054","tmdb_id":89571,"tmdb_type":"tv","type":"tv_series"},{"id":3164049,"title":"Prodigal
         Son","year":2019,"imdb_id":"tt10327354","tmdb_id":91875,"tmdb_type":"tv","type":"tv_series"},{"id":3162826,"title":"9-1-1:
         Lone Star","year":2020,"imdb_id":"tt10323338","tmdb_id":89393,"tmdb_type":"tv","type":"tv_series"},{"id":3162898,"title":"Almost
@@ -1120,8 +1116,7 @@ http_interactions:
         Tell the Truth","year":2016,"imdb_id":"tt5817158","tmdb_id":66784,"tmdb_type":"tv","type":"tv_series"},{"id":392255,"title":"Perfect
         Strangers","year":1986,"imdb_id":"tt0090501","tmdb_id":1786,"tmdb_type":"tv","type":"tv_series"},{"id":332196,"title":"Dirk
         Gently''s Holistic Detective Agency","year":2016,"imdb_id":"tt4047038","tmdb_id":67773,"tmdb_type":"tv","type":"tv_series"},{"id":329417,"title":"Death
-        Parade","year":2015,"imdb_id":"tt4279012","tmdb_id":61901,"tmdb_type":"tv","type":"tv_miniseries"},{"id":345646,"title":"Gangsta.","year":2015,"imdb_id":"tt5025394","tmdb_id":66390,"tmdb_type":"tv","type":"tv_series"},{"id":390026,"title":"Outlaw
-        Star","year":1998,"imdb_id":"tt0266171","tmdb_id":35106,"tmdb_type":"tv","type":"tv_series"},{"id":397717,"title":"Rage
+        Parade","year":2015,"imdb_id":"tt4279012","tmdb_id":61901,"tmdb_type":"tv","type":"tv_miniseries"},{"id":345646,"title":"Gangsta.","year":2015,"imdb_id":"tt5025394","tmdb_id":66390,"tmdb_type":"tv","type":"tv_series"},{"id":397717,"title":"Rage
         of Bahamut","year":2014,"imdb_id":"tt3981938","tmdb_id":61445,"tmdb_type":"tv","type":"tv_series"},{"id":3158733,"title":"Fixer
         Upper: Behind the Design","year":2018,"imdb_id":"tt8079518","tmdb_id":85067,"tmdb_type":"tv","type":"tv_series"},{"id":3127235,"title":"The
         Path","year":2016,"imdb_id":"tt4789576","tmdb_id":65227,"tmdb_type":"tv","type":"tv_series"},{"id":376570,"title":"Mayans
@@ -1133,7 +1128,7 @@ http_interactions:
         Powerpuff Girls","year":2016,"imdb_id":"tt4718304","tmdb_id":66149,"tmdb_type":"tv","type":"tv_series"},{"id":378269,"title":"Mighty
         Magiswords","year":2015,"imdb_id":"tt4847134","tmdb_id":68368,"tmdb_type":"tv","type":"tv_series"},{"id":3123696,"title":"The
         Hitchhiker''s Guide to the Galaxy","year":1981,"imdb_id":"tt0081874","tmdb_id":2048,"tmdb_type":"tv","type":"tv_series"},{"id":3163818,"title":"The
-        UnXplained","year":2019,"imdb_id":"tt10098498","tmdb_id":91371,"tmdb_type":"tv","type":"tv_series"},{"id":3127775,"title":"The
+        UnXplained","year":2019,"imdb_id":"tt10098498","tmdb_id":91371,"tmdb_type":"tv","type":"tv_series"},{"id":3158662,"title":"Shrill","year":2019,"imdb_id":"tt8962130","tmdb_id":85046,"tmdb_type":"tv","type":"tv_series"},{"id":3127775,"title":"The
         Purge","year":2018,"imdb_id":"tt6110648","tmdb_id":80213,"tmdb_type":"tv","type":"tv_series"},{"id":350796,"title":"Harvey
         Beaks","year":2015,"imdb_id":"tt3219170","tmdb_id":62487,"tmdb_type":"tv","type":"tv_series"},{"id":3131532,"title":"The
         Wrong Mans","year":2013,"imdb_id":"tt2603596","tmdb_id":60182,"tmdb_type":"tv","type":"tv_series"},{"id":3134057,"title":"Top
@@ -1184,7 +1179,8 @@ http_interactions:
         the Dark","year":2018,"imdb_id":"tt8427140","tmdb_id":122636,"tmdb_type":"tv","type":"tv_series"},{"id":358842,"title":"Ironside","year":1967,"imdb_id":"tt0061266","tmdb_id":4582,"tmdb_type":"tv","type":"tv_series"},{"id":376120,"title":"MasterChef
         Junior","year":2013,"imdb_id":"tt3038248","tmdb_id":57755,"tmdb_type":"tv","type":"tv_series"},{"id":376665,"title":"McHale''s
         Navy","year":1962,"imdb_id":"tt0055689","tmdb_id":11258,"tmdb_type":"tv","type":"tv_series"},{"id":379227,"title":"Mister
-        Ed","year":1958,"imdb_id":"tt0054557","tmdb_id":453,"tmdb_type":"tv","type":"tv_series"},{"id":382221,"title":"My
+        Ed","year":1958,"imdb_id":"tt0054557","tmdb_id":453,"tmdb_type":"tv","type":"tv_series"},{"id":379476,"title":"Mobile
+        Suit Gundam SEED","year":2002,"imdb_id":"tt0374407","tmdb_id":20111,"tmdb_type":"tv","type":"tv_series"},{"id":382221,"title":"My
         Mad Fat Diary","year":2013,"imdb_id":"tt2407574","tmdb_id":60616,"tmdb_type":"tv","type":"tv_series"},{"id":383673,"title":"NARUTO
         Spin-Off: Rock Lee & His Ninja Pals","year":2012,"imdb_id":"tt2301807","tmdb_id":43168,"tmdb_type":"tv","type":"tv_series"},{"id":387339,"title":"Obsession:
         Dark Desires","year":2013,"imdb_id":"tt2892016","tmdb_id":47986,"tmdb_type":"tv","type":"tv_series"},{"id":387734,"title":"Oh
@@ -1249,8 +1245,10 @@ http_interactions:
         Eric Andre Show","year":2012,"imdb_id":"tt2244495","tmdb_id":56590,"tmdb_type":"tv","type":"tv_series"},{"id":381007,"title":"Mr.
         Pickles","year":2013,"imdb_id":"tt2950342","tmdb_id":61593,"tmdb_type":"tv","type":"tv_series"},{"id":377758,"title":"Metalocalypse","year":2006,"imdb_id":"tt0839188","tmdb_id":653,"tmdb_type":"tv","type":"tv_series"},{"id":3100109,"title":"Rick
         and Morty","year":2013,"imdb_id":"tt2861424","tmdb_id":60625,"tmdb_type":"tv","type":"tv_series"},{"id":347980,"title":"Good
-        Girls","year":2018,"imdb_id":"tt6474378","tmdb_id":71715,"tmdb_type":"tv","type":"tv_series"},{"id":3114124,"title":"Superstore","year":2015,"imdb_id":"tt4477976","tmdb_id":62649,"tmdb_type":"tv","type":"tv_series"},{"id":3144350,"title":"Will
-        & Grace","year":1998,"imdb_id":"tt0157246","tmdb_id":4454,"tmdb_type":"tv","type":"tv_series"},{"id":3115881,"title":"Taken","year":2017,"imdb_id":"tt5052460","tmdb_id":68006,"tmdb_type":"tv","type":"tv_series"},{"id":315161,"title":"Blindspot","year":2015,"imdb_id":"tt4474344","tmdb_id":62710,"tmdb_type":"tv","type":"tv_series"},{"id":375700,"title":"Marlon","year":2017,"imdb_id":"tt5720168","tmdb_id":71887,"tmdb_type":"tv","type":"tv_series"},{"id":3124040,"title":"The
+        Girls","year":2018,"imdb_id":"tt6474378","tmdb_id":71715,"tmdb_type":"tv","type":"tv_series"},{"id":3114124,"title":"Superstore","year":2015,"imdb_id":"tt4477976","tmdb_id":62649,"tmdb_type":"tv","type":"tv_series"},{"id":368472,"title":"Law
+        & Order: Special Victims Unit","year":1999,"imdb_id":"tt0203259","tmdb_id":2734,"tmdb_type":"tv","type":"tv_series"},{"id":3144350,"title":"Will
+        & Grace","year":1998,"imdb_id":"tt0157246","tmdb_id":4454,"tmdb_type":"tv","type":"tv_series"},{"id":317350,"title":"Brooklyn
+        Nine-Nine","year":2013,"imdb_id":"tt2467372","tmdb_id":48891,"tmdb_type":"tv","type":"tv_series"},{"id":3115881,"title":"Taken","year":2017,"imdb_id":"tt5052460","tmdb_id":68006,"tmdb_type":"tv","type":"tv_series"},{"id":315161,"title":"Blindspot","year":2015,"imdb_id":"tt4474344","tmdb_id":62710,"tmdb_type":"tv","type":"tv_series"},{"id":375700,"title":"Marlon","year":2017,"imdb_id":"tt5720168","tmdb_id":71887,"tmdb_type":"tv","type":"tv_series"},{"id":3124040,"title":"The
         Incredible Hulk","year":1977,"imdb_id":"tt0077031","tmdb_id":648,"tmdb_type":"tv","type":"tv_series"},{"id":3170363,"title":"Law
         & Order: Organized Crime","year":2021,"imdb_id":"tt12677870","tmdb_id":106158,"tmdb_type":"tv","type":"tv_series"},{"id":3132065,"title":"This
         Is Us","year":2016,"imdb_id":"tt5555260","tmdb_id":67136,"tmdb_type":"tv","type":"tv_series"},{"id":375254,"title":"Manifest","year":2018,"imdb_id":"tt8421350","tmdb_id":79696,"tmdb_type":"tv","type":"tv_series"},{"id":3103650,"title":"Saturday
@@ -1278,8 +1276,9 @@ http_interactions:
         Cleveland Show","year":2009,"imdb_id":"tt1195935","tmdb_id":15632,"tmdb_type":"tv","type":"tv_series"},{"id":3129060,"title":"The
         Shield","year":2002,"imdb_id":"tt0286486","tmdb_id":1414,"tmdb_type":"tv","type":"tv_series"},{"id":3130016,"title":"The
         Terror","year":2018,"imdb_id":"tt2708480","tmdb_id":75191,"tmdb_type":"tv","type":"tv_series"},{"id":363849,"title":"Killing
-        Eve","year":2018,"imdb_id":"tt7016936","tmdb_id":72750,"tmdb_type":"tv","type":"tv_series"}],"page":5,"total_results":1994,"total_pages":8}'
-  recorded_at: Fri, 07 May 2021 03:02:08 GMT
+        Eve","year":2018,"imdb_id":"tt7016936","tmdb_id":72750,"tmdb_type":"tv","type":"tv_series"},{"id":364742,"title":"Kojak","year":1973,"imdb_id":"tt0069599","tmdb_id":3572,"tmdb_type":"tv","type":"tv_series"},{"id":373453,"title":"M*A*S*H","year":1972,"imdb_id":"tt0068098","tmdb_id":918,"tmdb_type":"tv","type":"tv_series"},{"id":3127996,"title":"The
+        Real Housewives of Potomac","year":2016,"imdb_id":"tt5327970","tmdb_id":65300,"tmdb_type":"tv","type":"tv_series"}],"page":5,"total_results":1980,"total_pages":8}'
+  recorded_at: Sat, 08 May 2021 23:04:43 GMT
 - request:
     method: get
     uri: https://api.watchmode.com/v1/list-titles/?apiKey=<WATCHMODE_API_KEY>&page=6&regions=US&source_ids=157&source_types=sub&type=movie
@@ -1299,7 +1298,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 07 May 2021 03:02:08 GMT
+      - Sat, 08 May 2021 23:04:43 GMT
       Server:
       - Apache/2.4.46 (Ubuntu)
       Access-Control-Allow-Origin:
@@ -1313,11 +1312,11 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '115'
       Retry-After:
-      - '52'
+      - '17'
       X-Account-Quota:
       - '1000'
       X-Account-Quota-Used:
-      - '474'
+      - '482'
       Vary:
       - Accept-Encoding
       Transfer-Encoding:
@@ -1326,16 +1325,14 @@ http_interactions:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
-      string: '{"titles":[{"id":364742,"title":"Kojak","year":1973,"imdb_id":"tt0069599","tmdb_id":3572,"tmdb_type":"tv","type":"tv_series"},{"id":373453,"title":"M*A*S*H","year":1972,"imdb_id":"tt0068098","tmdb_id":918,"tmdb_type":"tv","type":"tv_series"},{"id":3127996,"title":"The
-        Real Housewives of Potomac","year":2016,"imdb_id":"tt5327970","tmdb_id":65300,"tmdb_type":"tv","type":"tv_series"},{"id":382640,"title":"MythBusters","year":2003,"imdb_id":"tt0383126","tmdb_id":1428,"tmdb_type":"tv","type":"tv_series"},{"id":3104766,"title":"Second
+      string: '{"titles":[{"id":382640,"title":"MythBusters","year":2003,"imdb_id":"tt0383126","tmdb_id":1428,"tmdb_type":"tv","type":"tv_series"},{"id":3104766,"title":"Second
         Chance","year":2016,"imdb_id":"tt4378456","tmdb_id":64434,"tmdb_type":"tv","type":"tv_series"},{"id":3133979,"title":"Top
         Gear","year":2008,"imdb_id":"tt1248967","tmdb_id":7038,"tmdb_type":"tv","type":"tv_series"},{"id":327538,"title":"Damages","year":2007,"imdb_id":"tt0914387","tmdb_id":4920,"tmdb_type":"tv","type":"tv_series"},{"id":3157576,"title":"Wicked
         Tuna: Outer Banks","year":2014,"imdb_id":"tt4248510","tmdb_id":64054,"tmdb_type":"tv","type":"tv_series"},{"id":395040,"title":"Preacher","year":2016,"imdb_id":"tt5016504","tmdb_id":64230,"tmdb_type":"tv","type":"tv_series"},{"id":326122,"title":"Criminal
         Minds","year":2005,"imdb_id":"tt0452046","tmdb_id":4057,"tmdb_type":"tv","type":"tv_series"},{"id":315901,"title":"Bones","year":2005,"imdb_id":"tt0460627","tmdb_id":1911,"tmdb_type":"tv","type":"tv_series"},{"id":3124790,"title":"The
         L Word","year":2004,"imdb_id":"tt0330251","tmdb_id":3475,"tmdb_type":"tv","type":"tv_series"},{"id":3127992,"title":"The
         Real Housewives of New Jersey","year":2009,"imdb_id":"tt1411598","tmdb_id":18204,"tmdb_type":"tv","type":"tv_series"},{"id":3125932,"title":"The
-        Middle","year":2009,"imdb_id":"tt1442464","tmdb_id":1422,"tmdb_type":"tv","type":"tv_series"},{"id":381439,"title":"Murdoch
-        Mysteries","year":2008,"imdb_id":"tt1091909","tmdb_id":12786,"tmdb_type":"tv","type":"tv_series"},{"id":382197,"title":"My
+        Middle","year":2009,"imdb_id":"tt1442464","tmdb_id":1422,"tmdb_type":"tv","type":"tv_series"},{"id":382197,"title":"My
         Little Pony: Friendship Is Magic","year":2010,"imdb_id":"tt1751105","tmdb_id":33765,"tmdb_type":"tv","type":"tv_series"},{"id":3122495,"title":"The
         Fosters","year":2013,"imdb_id":"tt2262532","tmdb_id":46880,"tmdb_type":"tv","type":"tv_series"},{"id":3577,"title":"12
         Monkeys","year":2015,"imdb_id":"tt3148266","tmdb_id":60948,"tmdb_type":"tv","type":"tv_series"},{"id":314809,"title":"Black
@@ -1346,7 +1343,8 @@ http_interactions:
         and the Brain","year":1995,"imdb_id":"tt0112123","tmdb_id":2228,"tmdb_type":"tv","type":"tv_series"},{"id":346151,"title":"General
         Hospital","year":1963,"imdb_id":"tt0056758","tmdb_id":987,"tmdb_type":"tv","type":"tv_series"},{"id":378210,"title":"Midnight
         Sun","year":2016,"imdb_id":"tt4836846","tmdb_id":67394,"tmdb_type":"tv","type":"tv_series"},{"id":3103189,"title":"Samurai
-        7","year":2004,"imdb_id":"tt0482424","tmdb_id":5863,"tmdb_type":"tv","type":"tv_series"},{"id":3144699,"title":"Wiseguy","year":1987,"imdb_id":"tt0092484","tmdb_id":6550,"tmdb_type":"tv","type":"tv_series"},{"id":334027,"title":"Dragon
+        7","year":2004,"imdb_id":"tt0482424","tmdb_id":5863,"tmdb_type":"tv","type":"tv_series"},{"id":3144699,"title":"Wiseguy","year":1987,"imdb_id":"tt0092484","tmdb_id":6550,"tmdb_type":"tv","type":"tv_series"},{"id":3121836,"title":"The
+        Electric Company","year":1971,"imdb_id":"tt0066651","tmdb_id":4366,"tmdb_type":"tv","type":"tv_series"},{"id":334027,"title":"Dragon
         Ball GT","year":1996,"imdb_id":"tt0139774","tmdb_id":12697,"tmdb_type":"tv","type":"tv_series"},{"id":321990,"title":"Chivalry
         of a Failed Knight","year":2015,"imdb_id":"tt5100366","tmdb_id":67154,"tmdb_type":"tv","type":"tv_miniseries"},{"id":3162462,"title":"Tayo
         the Little Bus","year":2010,"imdb_id":"tt3270208","tmdb_id":45039,"tmdb_type":"tv","type":"tv_series"},{"id":3169008,"title":"Little
@@ -1414,9 +1412,9 @@ http_interactions:
         Trek: Deep Space Nine","year":1993,"imdb_id":"tt0106145","tmdb_id":580,"tmdb_type":"tv","type":"tv_series"},{"id":391333,"title":"Party
         Down","year":2009,"imdb_id":"tt1073507","tmdb_id":17287,"tmdb_type":"tv","type":"tv_series"},{"id":3130397,"title":"The
         Twilight Zone","year":1959,"imdb_id":"tt0052520","tmdb_id":6357,"tmdb_type":"tv","type":"tv_series"},{"id":334086,"title":"Drake
-        & Josh","year":2004,"imdb_id":"tt0363328","tmdb_id":2038,"tmdb_type":"tv","type":"tv_series"},{"id":354720,"title":"How
-        It''s Made","year":2001,"imdb_id":"tt0835010","tmdb_id":1749,"tmdb_type":"tv","type":"tv_series"},{"id":3101837,"title":"Rugrats","year":1991,"imdb_id":"tt0101188","tmdb_id":3022,"tmdb_type":"tv","type":"tv_series"},{"id":3121836,"title":"The
-        Electric Company","year":1971,"imdb_id":"tt0066651","tmdb_id":4366,"tmdb_type":"tv","type":"tv_series"},{"id":38933,"title":"The
+        & Josh","year":2004,"imdb_id":"tt0363328","tmdb_id":2038,"tmdb_type":"tv","type":"tv_series"},{"id":381439,"title":"Murdoch
+        Mysteries","year":2008,"imdb_id":"tt1091909","tmdb_id":12786,"tmdb_type":"tv","type":"tv_series"},{"id":354720,"title":"How
+        It''s Made","year":2001,"imdb_id":"tt0835010","tmdb_id":1749,"tmdb_type":"tv","type":"tv_series"},{"id":3101837,"title":"Rugrats","year":1991,"imdb_id":"tt0101188","tmdb_id":3022,"tmdb_type":"tv","type":"tv_series"},{"id":38933,"title":"The
         Heroic Legend of Arslan","year":2015,"imdb_id":"tt5023666","tmdb_id":62430,"tmdb_type":"tv","type":"tv_series"},{"id":363575,"title":"Kick
         Buttowski: Suburban Daredevil","year":2010,"imdb_id":"tt1600757","tmdb_id":17572,"tmdb_type":"tv","type":"tv_series"},{"id":3123389,"title":"The
         Guardian","year":2001,"imdb_id":"tt0285370","tmdb_id":1791,"tmdb_type":"tv","type":"tv_series"},{"id":360282,"title":"Jeremiah","year":2002,"imdb_id":"tt0290966","tmdb_id":184,"tmdb_type":"tv","type":"tv_series"},{"id":3130457,"title":"The
@@ -1436,11 +1434,9 @@ http_interactions:
         Goldbergs","year":2013,"imdb_id":"tt2712740","tmdb_id":49009,"tmdb_type":"tv","type":"tv_series"},{"id":353805,"title":"Homeland","year":2011,"imdb_id":"tt1796960","tmdb_id":1407,"tmdb_type":"tv","type":"tv_series"},{"id":389762,"title":"Our
         Cartoon President","year":2018,"imdb_id":"tt7689460","tmdb_id":75804,"tmdb_type":"tv","type":"tv_series"},{"id":3119940,"title":"The
         Bridge","year":2013,"imdb_id":"tt2406376","tmdb_id":47141,"tmdb_type":"tv","type":"tv_series"},{"id":355214,"title":"Hunderby","year":2012,"imdb_id":"tt2375858","tmdb_id":47806,"tmdb_type":"tv","type":"tv_series"},{"id":3119317,"title":"The
-        Bernie Mac Show","year":2001,"imdb_id":"tt0285341","tmdb_id":1693,"tmdb_type":"tv","type":"tv_series"},{"id":3125245,"title":"The
-        Little Couple","year":2009,"imdb_id":"tt1476894","tmdb_id":21651,"tmdb_type":"tv","type":"tv_series"},{"id":3166781,"title":"1000-lb
+        Bernie Mac Show","year":2001,"imdb_id":"tt0285341","tmdb_id":1693,"tmdb_type":"tv","type":"tv_series"},{"id":3166781,"title":"1000-lb
         Sisters","year":2020,"imdb_id":"tt11617414","tmdb_id":98410,"tmdb_type":"tv","type":"tv_series"},{"id":3166015,"title":"Welcome
-        to Plathville","year":2019,"imdb_id":"tt11399498","tmdb_id":95574,"tmdb_type":"tv","type":"tv_series"},{"id":32012,"title":"90
-        Day Fianc\u00e9: Happily Ever After?","year":2016,"imdb_id":"tt6142940","tmdb_id":67757,"tmdb_type":"tv","type":"tv_series"},{"id":3146860,"title":"Younger","year":2015,"imdb_id":"tt3288518","tmdb_id":62117,"tmdb_type":"tv","type":"tv_series"},{"id":317950,"title":"Burden
+        to Plathville","year":2019,"imdb_id":"tt11399498","tmdb_id":95574,"tmdb_type":"tv","type":"tv_series"},{"id":3146860,"title":"Younger","year":2015,"imdb_id":"tt3288518","tmdb_id":62117,"tmdb_type":"tv","type":"tv_series"},{"id":317950,"title":"Burden
         of Truth","year":2018,"imdb_id":"tt6987476","tmdb_id":72743,"tmdb_type":"tv","type":"tv_series"},{"id":3167053,"title":"Walker","year":2021,"imdb_id":"tt11006642","tmdb_id":99121,"tmdb_type":"tv","type":"tv_series"},{"id":3168610,"title":"The
         Secret of Skinwalker Ranch","year":2020,"imdb_id":"tt10589968","tmdb_id":101359,"tmdb_type":"tv","type":"tv_series"},{"id":36636,"title":"America''s
         Book of Secrets","year":2012,"imdb_id":"tt2198333","tmdb_id":60744,"tmdb_type":"tv","type":"tv_series"},{"id":3114554,"title":"Swamp
@@ -1449,21 +1445,20 @@ http_interactions:
         Curse of Oak Island","year":2014,"imdb_id":"tt3455408","tmdb_id":60603,"tmdb_type":"tv","type":"tv_series"},{"id":36201,"title":"Alone","year":2015,"imdb_id":"tt4803766","tmdb_id":63726,"tmdb_type":"tv","type":"tv_series"},{"id":368180,"title":"Last
         Man Standing","year":2011,"imdb_id":"tt1828327","tmdb_id":39297,"tmdb_type":"tv","type":"tv_series"},{"id":3108954,"title":"Snow
         White with the Red Hair","year":2015,"imdb_id":"tt4542568","tmdb_id":63087,"tmdb_type":"tv","type":"tv_series"},{"id":345739,"title":"Garfield
-        and Friends","year":1988,"imdb_id":"tt0094469","tmdb_id":4606,"tmdb_type":"tv","type":"tv_series"},{"id":311446,"title":"Bakuman\u3002","year":2010,"imdb_id":"tt1738419","tmdb_id":36041,"tmdb_type":"tv","type":"tv_series"},{"id":3100608,"title":"Roadies","year":2016,"imdb_id":"tt4270458","tmdb_id":65748,"tmdb_type":"tv","type":"tv_series"},{"id":36678,"title":"America''s
+        and Friends","year":1988,"imdb_id":"tt0094469","tmdb_id":4606,"tmdb_type":"tv","type":"tv_series"},{"id":311446,"title":"Bakuman\u3002","year":2010,"imdb_id":"tt1738419","tmdb_id":36041,"tmdb_type":"tv","type":"tv_series"},{"id":3100608,"title":"Roadies","year":2016,"imdb_id":"tt4270458","tmdb_id":65748,"tmdb_type":"tv","type":"tv_series"},{"id":3116699,"title":"Taxi","year":1978,"imdb_id":"tt0077089","tmdb_id":2251,"tmdb_type":"tv","type":"tv_series"},{"id":36678,"title":"America''s
         Most Wanted","year":1988,"imdb_id":"tt0094415","tmdb_id":1802,"tmdb_type":"tv","type":"tv_series"},{"id":390425,"title":"Packed
         to the Rafters","year":2008,"imdb_id":"tt1132600","tmdb_id":6754,"tmdb_type":"tv","type":"tv_series"},{"id":3158035,"title":"The
         Masked Singer","year":2019,"imdb_id":"tt7670568","tmdb_id":84910,"tmdb_type":"tv","type":"tv_series"},{"id":371076,"title":"Little
         Women: Atlanta","year":2016,"imdb_id":"tt5690880","tmdb_id":66009,"tmdb_type":"tv","type":"tv_series"},{"id":3146175,"title":"Immortals","year":2018,"imdb_id":"tt8063174","tmdb_id":82007,"tmdb_type":"tv","type":"tv_series"},{"id":3122335,"title":"The
         Firm","year":2012,"imdb_id":"tt1949012","tmdb_id":39255,"tmdb_type":"tv","type":"tv_series"},{"id":330902,"title":"Devil
         May Cry","year":2007,"imdb_id":"tt1048049","tmdb_id":12577,"tmdb_type":"tv","type":"tv_series"},{"id":3143904,"title":"Whose
-        Line Is It Anyway?","year":1988,"imdb_id":"tt0094580","tmdb_id":3269,"tmdb_type":"tv","type":"tv_series"},{"id":391906,"title":"Peep
-        Show","year":2003,"imdb_id":"tt0387764","tmdb_id":815,"tmdb_type":"tv","type":"tv_series"},{"id":3129332,"title":"The
+        Line Is It Anyway?","year":1988,"imdb_id":"tt0094580","tmdb_id":3269,"tmdb_type":"tv","type":"tv_series"},{"id":3129332,"title":"The
         Son","year":2017,"imdb_id":"tt3839822","tmdb_id":67232,"tmdb_type":"tv","type":"tv_series"},{"id":3135622,"title":"Trust","year":2018,"imdb_id":"tt5664952","tmdb_id":76177,"tmdb_type":"tv","type":"tv_series"},{"id":3105256,"title":"Sekirei","year":2008,"imdb_id":"tt1339238","tmdb_id":34805,"tmdb_type":"tv","type":"tv_series"},{"id":3159804,"title":"D.Gray-man","year":2006,"imdb_id":"tt0899258","tmdb_id":34141,"tmdb_type":"tv","type":"tv_series"},{"id":3110470,"title":"Spice
         and Wolf","year":2008,"imdb_id":"tt1158671","tmdb_id":26707,"tmdb_type":"tv","type":"tv_series"},{"id":3105525,"title":"Seraph
         of the End","year":2015,"imdb_id":"tt4584326","tmdb_id":62255,"tmdb_type":"tv","type":"tv_series"},{"id":375119,"title":"Man
         vs. Wild","year":2006,"imdb_id":"tt0883772","tmdb_id":4709,"tmdb_type":"tv","type":"tv_series"},{"id":325226,"title":"Coronation
         Street","year":1960,"imdb_id":"tt0053494","tmdb_id":291,"tmdb_type":"tv","type":"tv_series"},{"id":351613,"title":"Hell''s
-        Kitchen","year":2005,"imdb_id":"tt0437005","tmdb_id":2370,"tmdb_type":"tv","type":"tv_series"},{"id":355263,"title":"Hunter","year":1984,"imdb_id":"tt0086734","tmdb_id":4571,"tmdb_type":"tv","type":"tv_series"},{"id":355269,"title":"Hunter
+        Kitchen","year":2005,"imdb_id":"tt0437005","tmdb_id":2370,"tmdb_type":"tv","type":"tv_series"},{"id":355269,"title":"Hunter
         x Hunter","year":2011,"imdb_id":"tt2098220","tmdb_id":46298,"tmdb_type":"tv","type":"tv_series"},{"id":361873,"title":"K-Project","year":2012,"imdb_id":"tt2377452","tmdb_id":45799,"tmdb_type":"tv","type":"tv_series"},{"id":390036,"title":"Outnumbered","year":2007,"imdb_id":"tt1086191","tmdb_id":12784,"tmdb_type":"tv","type":"tv_series"},{"id":358528,"title":"Intervention","year":2005,"imdb_id":"tt0450920","tmdb_id":11145,"tmdb_type":"tv","type":"tv_series"},{"id":3109571,"title":"Son
         of Zorn","year":2016,"imdb_id":"tt4798814","tmdb_id":66844,"tmdb_type":"tv","type":"tv_series"},{"id":393238,"title":"Pitch","year":2016,"imdb_id":"tt5500158","tmdb_id":67147,"tmdb_type":"tv","type":"tv_series"},{"id":3101510,"title":"Rosewood","year":2015,"imdb_id":"tt4465472","tmdb_id":63329,"tmdb_type":"tv","type":"tv_series"},{"id":330924,"title":"Devious
         Maids","year":2013,"imdb_id":"tt2226342","tmdb_id":44242,"tmdb_type":"tv","type":"tv_series"},{"id":380207,"title":"Moone
@@ -1475,7 +1470,8 @@ http_interactions:
         Joy of Painting","year":1983,"imdb_id":"tt0383795","tmdb_id":10382,"tmdb_type":"tv","type":"tv_series"},{"id":3128322,"title":"The
         Rifleman","year":1958,"imdb_id":"tt0051308","tmdb_id":13859,"tmdb_type":"tv","type":"tv_series"},{"id":376672,"title":"McLeod''s
         Daughters","year":2001,"imdb_id":"tt0292414","tmdb_id":2041,"tmdb_type":"tv","type":"tv_series"},{"id":341228,"title":"Fear
-        Factor","year":2001,"imdb_id":"tt0278191","tmdb_id":320,"tmdb_type":"tv","type":"tv_series"},{"id":3132358,"title":"Threesome","year":2011,"imdb_id":"tt2071322","tmdb_id":41413,"tmdb_type":"tv","type":"tv_series"},{"id":3121468,"title":"The
+        Factor","year":2001,"imdb_id":"tt0278191","tmdb_id":320,"tmdb_type":"tv","type":"tv_series"},{"id":3132358,"title":"Threesome","year":2011,"imdb_id":"tt2071322","tmdb_id":41413,"tmdb_type":"tv","type":"tv_series"},{"id":391906,"title":"Peep
+        Show","year":2003,"imdb_id":"tt0387764","tmdb_id":815,"tmdb_type":"tv","type":"tv_series"},{"id":3121468,"title":"The
         Dick Van Dyke Show","year":1961,"imdb_id":"tt0054533","tmdb_id":2132,"tmdb_type":"tv","type":"tv_series"},{"id":3126979,"title":"The
         Only Way Is Essex","year":2010,"imdb_id":"tt1737565","tmdb_id":34284,"tmdb_type":"tv","type":"tv_series"},{"id":3132663,"title":"TIGER
         & BUNNY","year":2011,"imdb_id":"tt2061527","tmdb_id":39659,"tmdb_type":"tv","type":"tv_series"},{"id":380923,"title":"Mr.
@@ -1483,9 +1479,10 @@ http_interactions:
         Note","year":2006,"imdb_id":"tt0877057","tmdb_id":13916,"tmdb_type":"tv","type":"tv_series"},{"id":342472,"title":"Flavor
         of Love","year":2006,"imdb_id":"tt0488262","tmdb_id":1776,"tmdb_type":"tv","type":"tv_series"},{"id":332785,"title":"Doc
         Martin","year":2004,"imdb_id":"tt0408381","tmdb_id":2430,"tmdb_type":"tv","type":"tv_series"},{"id":3137595,"title":"Underground","year":2016,"imdb_id":"tt4522400","tmdb_id":64150,"tmdb_type":"tv","type":"tv_series"},{"id":3121420,"title":"The
-        Devil Is a Part-Timer!","year":2013,"imdb_id":"tt2622982","tmdb_id":45997,"tmdb_type":"tv","type":"tv_series"},{"id":3116699,"title":"Taxi","year":1978,"imdb_id":"tt0077089","tmdb_id":2251,"tmdb_type":"tv","type":"tv_series"},{"id":396238,"title":"Psycho-Pass","year":2012,"imdb_id":"tt2379308","tmdb_id":43865,"tmdb_type":"tv","type":"tv_series"},{"id":347832,"title":"Golden
+        Devil Is a Part-Timer!","year":2013,"imdb_id":"tt2622982","tmdb_id":45997,"tmdb_type":"tv","type":"tv_series"},{"id":396238,"title":"Psycho-Pass","year":2012,"imdb_id":"tt2379308","tmdb_id":43865,"tmdb_type":"tv","type":"tv_series"},{"id":347832,"title":"Golden
         Time","year":2013,"imdb_id":"tt3105452","tmdb_id":67389,"tmdb_type":"tv","type":"tv_series"},{"id":3134152,"title":"Toriko","year":2009,"imdb_id":"tt1899047","tmdb_id":38251,"tmdb_type":"tv","type":"tv_series"},{"id":3139208,"title":"Vampire
-        Knight","year":2008,"imdb_id":"tt1209393","tmdb_id":17149,"tmdb_type":"tv","type":"tv_series"},{"id":3165358,"title":"Yu-Gi-Oh!","year":1998,"imdb_id":"tt4834194","tmdb_id":36406,"tmdb_type":"tv","type":"tv_series"},{"id":377095,"title":"MEGALOBOX","year":2018,"imdb_id":"tt7965802","tmdb_id":77939,"tmdb_type":"tv","type":"tv_miniseries"},{"id":388699,"title":"One-Punch
+        Knight","year":2008,"imdb_id":"tt1209393","tmdb_id":17149,"tmdb_type":"tv","type":"tv_series"},{"id":33854,"title":"Accel
+        World","year":2012,"imdb_id":"tt2339875","tmdb_id":43167,"tmdb_type":"tv","type":"tv_series"},{"id":3165358,"title":"Yu-Gi-Oh!","year":1998,"imdb_id":"tt4834194","tmdb_id":36406,"tmdb_type":"tv","type":"tv_series"},{"id":377095,"title":"MEGALOBOX","year":2018,"imdb_id":"tt7965802","tmdb_id":77939,"tmdb_type":"tv","type":"tv_miniseries"},{"id":388699,"title":"One-Punch
         Man","year":2015,"imdb_id":"tt4508902","tmdb_id":63926,"tmdb_type":"tv","type":"tv_series"},{"id":344593,"title":"Full
         Metal Panic!","year":2002,"imdb_id":"tt0328739","tmdb_id":39379,"tmdb_type":"tv","type":"tv_series"},{"id":318693,"title":"CSI:
         Crime Scene Investigation","year":2000,"imdb_id":"tt0247082","tmdb_id":1431,"tmdb_type":"tv","type":"tv_series"},{"id":36695,"title":"America''s
@@ -1500,14 +1497,19 @@ http_interactions:
         to the Bottom of the Sea","year":1964,"imdb_id":"tt0057798","tmdb_id":321,"tmdb_type":"tv","type":"tv_series"},{"id":3170724,"title":"Animaniacs","year":2020,"imdb_id":"tt6951546","tmdb_id":107124,"tmdb_type":"tv","type":"tv_series"},{"id":3108546,"title":"Sleeper
         Cell","year":2005,"imdb_id":"tt0465353","tmdb_id":2409,"tmdb_type":"tv","type":"tv_series"},{"id":3119725,"title":"The
         Bob Newhart Show","year":1972,"imdb_id":"tt0068049","tmdb_id":1974,"tmdb_type":"tv","type":"tv_series"},{"id":3123402,"title":"The
-        Guest Book","year":2017,"imdb_id":"tt5990096","tmdb_id":72544,"tmdb_type":"tv","type":"tv_series"},{"id":335536,"title":"Eden
-        of the East","year":2009,"imdb_id":"tt1415054","tmdb_id":21750,"tmdb_type":"tv","type":"tv_series"},{"id":3155890,"title":"Devs","year":2020,"imdb_id":"tt8134186","tmdb_id":81349,"tmdb_type":"tv","type":"tv_miniseries"},{"id":3166978,"title":"Claymore","year":2007,"imdb_id":"tt0985344","tmdb_id":34791,"tmdb_type":"tv","type":"tv_series"},{"id":322930,"title":"Clannad","year":2007,"imdb_id":"tt1118804","tmdb_id":24835,"tmdb_type":"tv","type":"tv_series"},{"id":398072,"title":"Ranma
+        Guest Book","year":2017,"imdb_id":"tt5990096","tmdb_id":72544,"tmdb_type":"tv","type":"tv_series"},{"id":3155890,"title":"Devs","year":2020,"imdb_id":"tt8134186","tmdb_id":81349,"tmdb_type":"tv","type":"tv_miniseries"},{"id":3166978,"title":"Claymore","year":2007,"imdb_id":"tt0985344","tmdb_id":34791,"tmdb_type":"tv","type":"tv_series"},{"id":322930,"title":"Clannad","year":2007,"imdb_id":"tt1118804","tmdb_id":24835,"tmdb_type":"tv","type":"tv_series"},{"id":398072,"title":"Ranma
         \u00bd","year":1989,"imdb_id":"tt0096686","tmdb_id":57706,"tmdb_type":"tv","type":"tv_series"},{"id":3109635,"title":"Sonic
         X","year":2003,"imdb_id":"tt0367413","tmdb_id":10926,"tmdb_type":"tv","type":"tv_series"},{"id":3104476,"title":"Scream
         Queens","year":2015,"imdb_id":"tt4145384","tmdb_id":62046,"tmdb_type":"tv","type":"tv_series"},{"id":3156178,"title":"Molang","year":2015,"imdb_id":"tt6046238","tmdb_id":84508,"tmdb_type":"tv","type":"tv_series"},{"id":3106168,"title":"Shameless","year":2004,"imdb_id":"tt0377260","tmdb_id":1906,"tmdb_type":"tv","type":"tv_series"},{"id":3141870,"title":"Wander
         Over Yonder","year":2013,"imdb_id":"tt2252938","tmdb_id":45013,"tmdb_type":"tv","type":"tv_series"},{"id":311872,"title":"Barefoot
-        Contessa","year":2002,"imdb_id":"tt0783322","tmdb_id":4410,"tmdb_type":"tv","type":"tv_series"}],"page":6,"total_results":1994,"total_pages":8}'
-  recorded_at: Fri, 07 May 2021 03:02:08 GMT
+        Contessa","year":2002,"imdb_id":"tt0783322","tmdb_id":4410,"tmdb_type":"tv","type":"tv_series"},{"id":3123216,"title":"The
+        Great Food Truck Race","year":2010,"imdb_id":"tt1711420","tmdb_id":33665,"tmdb_type":"tv","type":"tv_series"},{"id":363663,"title":"Kids
+        Baking Championship","year":2015,"imdb_id":"tt4328676","tmdb_id":61987,"tmdb_type":"tv","type":"tv_series"},{"id":399679,"title":"Restaurant:
+        Impossible","year":2011,"imdb_id":"tt1771742","tmdb_id":35358,"tmdb_type":"tv","type":"tv_series"},{"id":313349,"title":"Best
+        Baker In America","year":2017,"imdb_id":"tt7603564","tmdb_id":74560,"tmdb_type":"tv","type":"tv_series"},{"id":395988,"title":"Property
+        Brothers","year":2011,"imdb_id":"tt1827882","tmdb_id":35058,"tmdb_type":"tv","type":"tv_series"},{"id":342566,"title":"Flip
+        or Flop","year":2013,"imdb_id":"tt2902088","tmdb_id":62618,"tmdb_type":"tv","type":"tv_series"}],"page":6,"total_results":1980,"total_pages":8}'
+  recorded_at: Sat, 08 May 2021 23:04:43 GMT
 - request:
     method: get
     uri: https://api.watchmode.com/v1/list-titles/?apiKey=<WATCHMODE_API_KEY>&page=7&regions=US&source_ids=157&source_types=sub&type=movie
@@ -1527,7 +1529,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 07 May 2021 03:02:08 GMT
+      - Sat, 08 May 2021 23:04:43 GMT
       Server:
       - Apache/2.4.46 (Ubuntu)
       Access-Control-Allow-Origin:
@@ -1541,11 +1543,11 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '114'
       Retry-After:
-      - '52'
+      - '17'
       X-Account-Quota:
       - '1000'
       X-Account-Quota-Used:
-      - '475'
+      - '483'
       Vary:
       - Accept-Encoding
       Transfer-Encoding:
@@ -1554,19 +1556,14 @@ http_interactions:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
-      string: '{"titles":[{"id":3123216,"title":"The Great Food Truck Race","year":2010,"imdb_id":"tt1711420","tmdb_id":33665,"tmdb_type":"tv","type":"tv_series"},{"id":363663,"title":"Kids
-        Baking Championship","year":2015,"imdb_id":"tt4328676","tmdb_id":61987,"tmdb_type":"tv","type":"tv_series"},{"id":399679,"title":"Restaurant:
-        Impossible","year":2011,"imdb_id":"tt1771742","tmdb_id":35358,"tmdb_type":"tv","type":"tv_series"},{"id":313349,"title":"Best
-        Baker In America","year":2017,"imdb_id":"tt7603564","tmdb_id":74560,"tmdb_type":"tv","type":"tv_series"},{"id":395988,"title":"Property
-        Brothers","year":2011,"imdb_id":"tt1827882","tmdb_id":35058,"tmdb_type":"tv","type":"tv_series"},{"id":342566,"title":"Flip
-        or Flop","year":2013,"imdb_id":"tt2902088","tmdb_id":62618,"tmdb_type":"tv","type":"tv_series"},{"id":372658,"title":"Love
-        It or List It","year":2008,"imdb_id":"tt1773182","tmdb_id":33927,"tmdb_type":"tv","type":"tv_series"},{"id":353757,"title":"Home
+      string: '{"titles":[{"id":372658,"title":"Love It or List It","year":2008,"imdb_id":"tt1773182","tmdb_id":33927,"tmdb_type":"tv","type":"tv_series"},{"id":353757,"title":"Home
         Town","year":2016,"imdb_id":"tt6666966","tmdb_id":71359,"tmdb_type":"tv","type":"tv_series"},{"id":3125021,"title":"The
         League of Gentlemen","year":1999,"imdb_id":"tt0184135","tmdb_id":2349,"tmdb_type":"tv","type":"tv_series"},{"id":352551,"title":"Highschool
         of the Dead","year":2010,"imdb_id":"tt1685401","tmdb_id":56998,"tmdb_type":"tv","type":"tv_series"},{"id":3124664,"title":"The
         Kids Are Alright","year":2018,"imdb_id":"tt7440732","tmdb_id":81923,"tmdb_type":"tv","type":"tv_series"},{"id":3128295,"title":"The
         Riches","year":2007,"imdb_id":"tt0496343","tmdb_id":2933,"tmdb_type":"tv","type":"tv_series"},{"id":344856,"title":"The
-        Future Diary","year":2011,"imdb_id":"tt2069441","tmdb_id":46671,"tmdb_type":"tv","type":"tv_series"},{"id":3166049,"title":"ID:
+        Future Diary","year":2011,"imdb_id":"tt2069441","tmdb_id":46671,"tmdb_type":"tv","type":"tv_series"},{"id":390026,"title":"Outlaw
+        Star","year":1998,"imdb_id":"tt0266171","tmdb_id":35106,"tmdb_type":"tv","type":"tv_series"},{"id":3166049,"title":"ID:
         INVADED","year":2020,"imdb_id":"tt10954274","tmdb_id":92602,"tmdb_type":"tv","type":"tv_series"},{"id":327088,"title":"DCI
         Banks","year":2010,"imdb_id":"tt1652216","tmdb_id":40675,"tmdb_type":"tv","type":"tv_series"},{"id":3107843,"title":"Single
         Parents","year":2018,"imdb_id":"tt7845644","tmdb_id":81127,"tmdb_type":"tv","type":"tv_series"},{"id":3158273,"title":"The
@@ -1594,16 +1591,14 @@ http_interactions:
         Brothers: Buying and Selling","year":2012,"imdb_id":"tt2272112","tmdb_id":67392,"tmdb_type":"tv","type":"tv_series"},{"id":340521,"title":"Family
         By the Ton","year":2018,"imdb_id":"tt7826126","tmdb_id":76269,"tmdb_type":"tv","type":"tv_series"},{"id":3116378,"title":"Tanked","year":2011,"imdb_id":"tt1849622","tmdb_id":61329,"tmdb_type":"tv","type":"tv_series"},{"id":319800,"title":"Cardinal","year":2017,"imdb_id":"tt5583512","tmdb_id":67743,"tmdb_type":"tv","type":"tv_series"},{"id":321050,"title":"Chance","year":2016,"imdb_id":"tt5620076","tmdb_id":66912,"tmdb_type":"tv","type":"tv_series"},{"id":331882,"title":"Difficult
         People","year":2015,"imdb_id":"tt4676574","tmdb_id":63353,"tmdb_type":"tv","type":"tv_series"},{"id":379269,"title":"Mistresses","year":2013,"imdb_id":"tt2295809","tmdb_id":43856,"tmdb_type":"tv","type":"tv_series"},{"id":3110387,"title":"Speechless","year":2016,"imdb_id":"tt5592146","tmdb_id":67040,"tmdb_type":"tv","type":"tv_series"},{"id":3111354,"title":"Star","year":2016,"imdb_id":"tt4941240","tmdb_id":68780,"tmdb_type":"tv","type":"tv_series"},{"id":3144752,"title":"Witches
-        of East End","year":2013,"imdb_id":"tt2288064","tmdb_id":60557,"tmdb_type":"tv","type":"tv_series"},{"id":3158662,"title":"Shrill","year":2019,"imdb_id":"tt8962130","tmdb_id":85046,"tmdb_type":"tv","type":"tv_series"},{"id":3161727,"title":"Ramy","year":2019,"imdb_id":"tt7649694","tmdb_id":87382,"tmdb_type":"tv","type":"tv_series"},{"id":329239,"title":"Deadbeat","year":2014,"imdb_id":"tt3147316","tmdb_id":62234,"tmdb_type":"tv","type":"tv_series"},{"id":341301,"title":"Feed
+        of East End","year":2013,"imdb_id":"tt2288064","tmdb_id":60557,"tmdb_type":"tv","type":"tv_series"},{"id":3161727,"title":"Ramy","year":2019,"imdb_id":"tt7649694","tmdb_id":87382,"tmdb_type":"tv","type":"tv_series"},{"id":329239,"title":"Deadbeat","year":2014,"imdb_id":"tt3147316","tmdb_id":62234,"tmdb_type":"tv","type":"tv_series"},{"id":341301,"title":"Feed
         the Beast","year":2016,"imdb_id":"tt5363766","tmdb_id":66316,"tmdb_type":"tv","type":"tv_series"},{"id":3164163,"title":"Treadstone","year":2019,"imdb_id":"tt8289480","tmdb_id":83949,"tmdb_type":"tv","type":"tv_series"},{"id":383504,"title":"Naked
         and Afraid XL","year":2015,"imdb_id":"tt4791250","tmdb_id":63451,"tmdb_type":"tv","type":"tv_series"},{"id":369147,"title":"Legit","year":2013,"imdb_id":"tt2400391","tmdb_id":46405,"tmdb_type":"tv","type":"tv_series"},{"id":375066,"title":"Man
         Seeking Woman","year":2015,"imdb_id":"tt4189492","tmdb_id":61871,"tmdb_type":"tv","type":"tv_series"},{"id":383714,"title":"Nashville","year":2012,"imdb_id":"tt2281375","tmdb_id":44549,"tmdb_type":"tv","type":"tv_series"},{"id":397017,"title":"Queen
-        Sugar","year":2016,"imdb_id":"tt4419214","tmdb_id":67679,"tmdb_type":"tv","type":"tv_series"},{"id":3162313,"title":"Gold
-        Rush: Dave Turin''s Lost Mine","year":2019,"imdb_id":"tt9703198","tmdb_id":88273,"tmdb_type":"tv","type":"tv_series"},{"id":318931,"title":"Cake
+        Sugar","year":2016,"imdb_id":"tt4419214","tmdb_id":67679,"tmdb_type":"tv","type":"tv_series"},{"id":318931,"title":"Cake
         Wars","year":2015,"imdb_id":"tt4718570","tmdb_id":67823,"tmdb_type":"tv","type":"tv_series"},{"id":317718,"title":"Buffy
         the Vampire Slayer","year":1997,"imdb_id":"tt0118276","tmdb_id":95,"tmdb_type":"tv","type":"tv_series"},{"id":3105805,"title":"Sex&Drugs&Rock&Roll","year":2015,"imdb_id":"tt3594982","tmdb_id":62936,"tmdb_type":"tv","type":"tv_series"},{"id":347933,"title":"Good
-        Bones","year":2016,"imdb_id":"tt5710198","tmdb_id":71956,"tmdb_type":"tv","type":"tv_series"},{"id":3112610,"title":"Street
-        Outlaws","year":2013,"imdb_id":"tt3027156","tmdb_id":61019,"tmdb_type":"tv","type":"tv_series"},{"id":3162442,"title":"Four
+        Bones","year":2016,"imdb_id":"tt5710198","tmdb_id":71956,"tmdb_type":"tv","type":"tv_series"},{"id":3162442,"title":"Four
         Weddings and a Funeral","year":2019,"imdb_id":"tt7587362","tmdb_id":84282,"tmdb_type":"tv","type":"tv_series"},{"id":3168469,"title":"Solar
         Opposites","year":2020,"imdb_id":"tt8910922","tmdb_id":97645,"tmdb_type":"tv","type":"tv_series"},{"id":3163111,"title":"Cheerleader
         Generation","year":2019,"imdb_id":"tt9854758","tmdb_id":90218,"tmdb_type":"tv","type":"tv_series"},{"id":384029,"title":"Nazi
@@ -1654,7 +1649,7 @@ http_interactions:
         Inc.","year":2015,"imdb_id":"tt4480608","tmdb_id":65425,"tmdb_type":"tv","type":"tv_series"},{"id":382384,"title":"My
         Strange Addiction","year":2010,"imdb_id":"tt1809014","tmdb_id":35308,"tmdb_type":"tv","type":"tv_series"},{"id":344487,"title":"F*ck
         That''s Delicious","year":2016,"imdb_id":"tt5866048","tmdb_id":67733,"tmdb_type":"tv","type":"tv_series"},{"id":3102949,"title":"Salem","year":2014,"imdb_id":"tt2963254","tmdb_id":60905,"tmdb_type":"tv","type":"tv_series"},{"id":3136397,"title":"Tyrant","year":2014,"imdb_id":"tt2568204","tmdb_id":60972,"tmdb_type":"tv","type":"tv_series"},{"id":349127,"title":"grown-ish","year":2018,"imdb_id":"tt7018644","tmdb_id":71885,"tmdb_type":"tv","type":"tv_series"},{"id":3117070,"title":"Teenage
-        Mutant Ninja Turtles Rise of the Turtles","year":2012,"imdb_id":"tt1877889","tmdb_id":186037,"tmdb_type":"movie","type":"tv_series"},{"id":321851,"title":"Childrens
+        Mutant Ninja Turtles","year":2012,"imdb_id":"tt1877889","tmdb_id":51817,"tmdb_type":"tv","type":"tv_series"},{"id":321851,"title":"Childrens
         Hospital","year":2008,"imdb_id":"tt1325113","tmdb_id":33056,"tmdb_type":"tv","type":"tv_series"},{"id":327564,"title":"Damien","year":2016,"imdb_id":"tt4337944","tmdb_id":19033,"tmdb_type":"tv","type":"tv_series"},{"id":378977,"title":"Misfits","year":2009,"imdb_id":"tt1548850","tmdb_id":31295,"tmdb_type":"tv","type":"tv_series"},{"id":368891,"title":"Leah
         Remini: Scientology and the Aftermath","year":2016,"imdb_id":"tt6244192","tmdb_id":68901,"tmdb_type":"tv","type":"tv_series"},{"id":34775,"title":"Agent
         X","year":2015,"imdb_id":"tt3499120","tmdb_id":63645,"tmdb_type":"tv","type":"tv_series"},{"id":381426,"title":"Murder
@@ -1679,9 +1674,9 @@ http_interactions:
         Fall Guy","year":1981,"imdb_id":"tt0081859","tmdb_id":5031,"tmdb_type":"tv","type":"tv_series"},{"id":371357,"title":"Living
         Single","year":1993,"imdb_id":"tt0106056","tmdb_id":4270,"tmdb_type":"tv","type":"tv_series"},{"id":361889,"title":"K-ON!","year":2009,"imdb_id":"tt1410218","tmdb_id":42253,"tmdb_type":"tv","type":"tv_series"},{"id":3123483,"title":"The
         Handmaid''s Tale","year":2017,"imdb_id":"tt5834204","tmdb_id":69478,"tmdb_type":"tv","type":"tv_series"},{"id":348599,"title":"Gravity
-        Falls","year":2012,"imdb_id":"tt1865718","tmdb_id":40075,"tmdb_type":"tv","type":"tv_series"},{"id":3111490,"title":"Star
-        vs. the Forces of Evil","year":2015,"imdb_id":"tt2758770","tmdb_id":61923,"tmdb_type":"tv","type":"tv_series"},{"id":332787,"title":"Doc
-        McStuffins","year":2012,"imdb_id":"tt1710295","tmdb_id":46262,"tmdb_type":"tv","type":"tv_series"},{"id":3164097,"title":"Motherland:
+        Falls","year":2012,"imdb_id":"tt1865718","tmdb_id":40075,"tmdb_type":"tv","type":"tv_series"},{"id":332787,"title":"Doc
+        McStuffins","year":2012,"imdb_id":"tt1710295","tmdb_id":46262,"tmdb_type":"tv","type":"tv_series"},{"id":3111490,"title":"Star
+        vs. the Forces of Evil","year":2015,"imdb_id":"tt2758770","tmdb_id":61923,"tmdb_type":"tv","type":"tv_series"},{"id":3164097,"title":"Motherland:
         Fort Salem","year":2020,"imdb_id":"tt9900092","tmdb_id":91977,"tmdb_type":"tv","type":"tv_series"},{"id":377278,"title":"Melissa
         & Joey","year":2010,"imdb_id":"tt1597420","tmdb_id":31936,"tmdb_type":"tv","type":"tv_series"},{"id":374639,"title":"Make
         It or Break It","year":2009,"imdb_id":"tt1332030","tmdb_id":17518,"tmdb_type":"tv","type":"tv_series"},{"id":3377,"title":"10
@@ -1697,19 +1692,17 @@ http_interactions:
         Practice","year":2007,"imdb_id":"tt0972412","tmdb_id":3172,"tmdb_type":"tv","type":"tv_series"},{"id":399866,"title":"Revenge","year":2011,"imdb_id":"tt1837642","tmdb_id":39358,"tmdb_type":"tv","type":"tv_series"},{"id":330554,"title":"Desperate
         Housewives","year":2004,"imdb_id":"tt0410975","tmdb_id":693,"tmdb_type":"tv","type":"tv_series"},{"id":370156,"title":"Lie
         to Me","year":2009,"imdb_id":"tt1235099","tmdb_id":8358,"tmdb_type":"tv","type":"tv_series"},{"id":3143658,"title":"White
-        Collar","year":2009,"imdb_id":"tt1358522","tmdb_id":21510,"tmdb_type":"tv","type":"tv_series"},{"id":372371,"title":"Lost","year":2004,"imdb_id":"tt0411008","tmdb_id":4607,"tmdb_type":"tv","type":"tv_series"},{"id":3138044,"title":"Unsolved
-        Mysteries","year":1987,"imdb_id":"tt0094574","tmdb_id":126,"tmdb_type":"tv","type":"tv_series"},{"id":348348,"title":"Graceland","year":2013,"imdb_id":"tt2393813","tmdb_id":47318,"tmdb_type":"tv","type":"tv_series"},{"id":3111127,"title":"St.
+        Collar","year":2009,"imdb_id":"tt1358522","tmdb_id":21510,"tmdb_type":"tv","type":"tv_series"},{"id":348348,"title":"Graceland","year":2013,"imdb_id":"tt2393813","tmdb_id":47318,"tmdb_type":"tv","type":"tv_series"},{"id":3111127,"title":"St.
         Elsewhere","year":1982,"imdb_id":"tt0083483","tmdb_id":30,"tmdb_type":"tv","type":"tv_series"},{"id":316213,"title":"Boston
-        Legal","year":2004,"imdb_id":"tt0402711","tmdb_id":4598,"tmdb_type":"tv","type":"tv_series"},{"id":348799,"title":"Greek","year":2007,"imdb_id":"tt0976014","tmdb_id":1242,"tmdb_type":"tv","type":"tv_series"},{"id":321710,"title":"Chicago
-        Fire","year":2012,"imdb_id":"tt2261391","tmdb_id":44006,"tmdb_type":"tv","type":"tv_series"},{"id":391142,"title":"Parenthood","year":2010,"imdb_id":"tt1416765","tmdb_id":21762,"tmdb_type":"tv","type":"tv_series"},{"id":343242,"title":"Forensic
-        Files","year":1996,"imdb_id":"tt0247882","tmdb_id":11105,"tmdb_type":"tv","type":"tv_series"},{"id":3123554,"title":"Tyler
+        Legal","year":2004,"imdb_id":"tt0402711","tmdb_id":4598,"tmdb_type":"tv","type":"tv_series"},{"id":348799,"title":"Greek","year":2007,"imdb_id":"tt0976014","tmdb_id":1242,"tmdb_type":"tv","type":"tv_series"},{"id":391142,"title":"Parenthood","year":2010,"imdb_id":"tt1416765","tmdb_id":21762,"tmdb_type":"tv","type":"tv_series"},{"id":343242,"title":"Forensic
+        Files","year":1996,"imdb_id":"tt0247882","tmdb_id":11105,"tmdb_type":"tv","type":"tv_series"},{"id":3138044,"title":"Unsolved
+        Mysteries","year":1987,"imdb_id":"tt0094574","tmdb_id":126,"tmdb_type":"tv","type":"tv_series"},{"id":3123554,"title":"Tyler
         Perry''s The Haves and the Have Nots","year":2013,"imdb_id":"tt2729716","tmdb_id":46441,"tmdb_type":"tv","type":"tv_series"},{"id":339716,"title":"Extreme
         Makeover: Home Edition","year":2003,"imdb_id":"tt0388595","tmdb_id":721,"tmdb_type":"tv","type":"tv_series"},{"id":3166411,"title":"Infinite
         Dendrogram","year":2020,"imdb_id":"tt11295582","tmdb_id":94649,"tmdb_type":"tv","type":"tv_series"},{"id":3130937,"title":"The
         Wallflower","year":2006,"imdb_id":"tt0892861","tmdb_id":899,"tmdb_type":"tv","type":"tv_series"},{"id":3171185,"title":"The
         World Ends With You: The Animation","year":2021,"imdb_id":"tt12643520","tmdb_id":105249,"tmdb_type":"tv","type":"tv_series"},{"id":3171404,"title":"Horimiya","year":2021,"imdb_id":"tt13103134","tmdb_id":110070,"tmdb_type":"tv","type":"tv_series"},{"id":3171655,"title":"Mushoku
-        Tensei: Jobless Reincarnation","year":2021,"imdb_id":"tt13293588","tmdb_id":94664,"tmdb_type":"tv","type":"tv_series"},{"id":379476,"title":"Mobile
-        Suit Gundam SEED","year":2002,"imdb_id":"tt0374407","tmdb_id":20111,"tmdb_type":"tv","type":"tv_series"},{"id":3133574,"title":"Tokyo
+        Tensei: Jobless Reincarnation","year":2021,"imdb_id":"tt13293588","tmdb_id":94664,"tmdb_type":"tv","type":"tv_series"},{"id":3133574,"title":"Tokyo
         Ghoul","year":2014,"imdb_id":"tt3741634","tmdb_id":61374,"tmdb_type":"tv","type":"tv_series"},{"id":334026,"title":"Dragon
         Ball","year":1986,"imdb_id":"tt0088509","tmdb_id":12609,"tmdb_type":"tv","type":"tv_series"},{"id":3143505,"title":"When
         They Cry","year":2006,"imdb_id":"tt0845738","tmdb_id":802511,"tmdb_type":"movie","type":"tv_series"},{"id":39814,"title":"Attack
@@ -1727,14 +1720,24 @@ http_interactions:
         Game Night","year":2013,"imdb_id":"tt3037520","tmdb_id":51502,"tmdb_type":"tv","type":"tv_series"},{"id":3171316,"title":"Madagascar:
         A Little Wild","year":2020,"imdb_id":"tt11714912","tmdb_id":109330,"tmdb_type":"tv","type":"tv_series"},{"id":3171685,"title":"The
         Mighty Ones","year":2020,"imdb_id":"tt11714946","tmdb_id":112063,"tmdb_type":"tv","type":"tv_series"},{"id":3164708,"title":"A
-        Little Late with Lilly Singh","year":2019,"imdb_id":"tt10023178","tmdb_id":93660,"tmdb_type":"tv","type":"tv_series"},{"id":368472,"title":"Law
-        & Order: Special Victims Unit","year":1999,"imdb_id":"tt0203259","tmdb_id":2734,"tmdb_type":"tv","type":"tv_series"},{"id":3167207,"title":"Transplant","year":2020,"imdb_id":"tt10936342","tmdb_id":99530,"tmdb_type":"tv","type":"tv_series"},{"id":384493,"title":"New
+        Little Late with Lilly Singh","year":2019,"imdb_id":"tt10023178","tmdb_id":93660,"tmdb_type":"tv","type":"tv_series"},{"id":3167207,"title":"Transplant","year":2020,"imdb_id":"tt10936342","tmdb_id":99530,"tmdb_type":"tv","type":"tv_series"},{"id":384493,"title":"New
         Amsterdam","year":2018,"imdb_id":"tt7817340","tmdb_id":80350,"tmdb_type":"tv","type":"tv_series"},{"id":321720,"title":"Chicago
         P.D.","year":2014,"imdb_id":"tt2805096","tmdb_id":58841,"tmdb_type":"tv","type":"tv_series"},{"id":391235,"title":"Parks
         and Recreation","year":2009,"imdb_id":"tt1266020","tmdb_id":8592,"tmdb_type":"tv","type":"tv_series"},{"id":321487,"title":"Cheers","year":1982,"imdb_id":"tt0083399","tmdb_id":141,"tmdb_type":"tv","type":"tv_series"},{"id":3101492,"title":"Roseanne","year":1988,"imdb_id":"tt0094540","tmdb_id":2706,"tmdb_type":"tv","type":"tv_series"},{"id":36901,"title":"American
         Ninja Warrior","year":2009,"imdb_id":"tt1587934","tmdb_id":37913,"tmdb_type":"tv","type":"tv_series"},{"id":321718,"title":"Chicago
-        Med","year":2015,"imdb_id":"tt4655480","tmdb_id":62650,"tmdb_type":"tv","type":"tv_series"}],"page":7,"total_results":1994,"total_pages":8}'
-  recorded_at: Fri, 07 May 2021 03:02:08 GMT
+        Med","year":2015,"imdb_id":"tt4655480","tmdb_id":62650,"tmdb_type":"tv","type":"tv_series"},{"id":336119,"title":"Second
+        chance","year":2005,"imdb_id":"tt0459683","tmdb_id":4879,"tmdb_type":"tv","type":"tv_series"},{"id":379416,"title":"Miz
+        & Mrs","year":2018,"imdb_id":"tt8050736","tmdb_id":81134,"tmdb_type":"tv","type":"tv_series"},{"id":337244,"title":"Ellen''s
+        Game of Games","year":2017,"imdb_id":"tt7369770","tmdb_id":76048,"tmdb_type":"tv","type":"tv_series"},{"id":368289,"title":"Late
+        Night with Seth Meyers","year":2014,"imdb_id":"tt3513388","tmdb_id":61818,"tmdb_type":"tv","type":"tv_series"},{"id":3141522,"title":"WWE
+        SmackDown","year":1999,"imdb_id":"tt0227972","tmdb_id":1549,"tmdb_type":"tv","type":"tv_series"},{"id":3102676,"title":"Sabrina,
+        the Teenage Witch","year":1996,"imdb_id":"tt0115341","tmdb_id":605,"tmdb_type":"tv","type":"tv_series"},{"id":31329,"title":"30
+        Rock","year":2006,"imdb_id":"tt0496424","tmdb_id":4608,"tmdb_type":"tv","type":"tv_series"},{"id":3108582,"title":"Sliders","year":1995,"imdb_id":"tt0112167","tmdb_id":1649,"tmdb_type":"tv","type":"tv_series"},{"id":344115,"title":"Friday
+        Night Lights","year":2006,"imdb_id":"tt0758745","tmdb_id":4278,"tmdb_type":"tv","type":"tv_series"},{"id":3103787,"title":"Saved
+        by the Bell","year":1989,"imdb_id":"tt0096694","tmdb_id":4345,"tmdb_type":"tv","type":"tv_series"},{"id":3173662,"title":"Young
+        Rock","year":2021,"imdb_id":"tt11639952","tmdb_id":97754,"tmdb_type":"tv","type":"tv_series"},{"id":37377,"title":"Ancient
+        Aliens","year":2009,"imdb_id":"tt1643266","tmdb_id":32608,"tmdb_type":"tv","type":"tv_series"}],"page":7,"total_results":1980,"total_pages":8}'
+  recorded_at: Sat, 08 May 2021 23:04:43 GMT
 - request:
     method: get
     uri: https://api.watchmode.com/v1/list-titles/?apiKey=<WATCHMODE_API_KEY>&page=8&regions=US&source_ids=157&source_types=sub&type=movie
@@ -1754,7 +1757,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 07 May 2021 03:02:08 GMT
+      - Sat, 08 May 2021 23:04:43 GMT
       Server:
       - Apache/2.4.46 (Ubuntu)
       Access-Control-Allow-Origin:
@@ -1768,11 +1771,11 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '113'
       Retry-After:
-      - '52'
+      - '17'
       X-Account-Quota:
       - '1000'
       X-Account-Quota-Used:
-      - '476'
+      - '484'
       Vary:
       - Accept-Encoding
       Transfer-Encoding:
@@ -1781,18 +1784,7 @@ http_interactions:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
-      string: '{"titles":[{"id":336119,"title":"Second chance","year":2005,"imdb_id":"tt0459683","tmdb_id":4879,"tmdb_type":"tv","type":"tv_series"},{"id":379416,"title":"Miz
-        & Mrs","year":2018,"imdb_id":"tt8050736","tmdb_id":81134,"tmdb_type":"tv","type":"tv_series"},{"id":337244,"title":"Ellen''s
-        Game of Games","year":2017,"imdb_id":"tt7369770","tmdb_id":76048,"tmdb_type":"tv","type":"tv_series"},{"id":368289,"title":"Late
-        Night with Seth Meyers","year":2014,"imdb_id":"tt3513388","tmdb_id":61818,"tmdb_type":"tv","type":"tv_series"},{"id":3141522,"title":"WWE
-        SmackDown","year":1999,"imdb_id":"tt0227972","tmdb_id":1549,"tmdb_type":"tv","type":"tv_series"},{"id":3102676,"title":"Sabrina,
-        the Teenage Witch","year":1996,"imdb_id":"tt0115341","tmdb_id":605,"tmdb_type":"tv","type":"tv_series"},{"id":31329,"title":"30
-        Rock","year":2006,"imdb_id":"tt0496424","tmdb_id":4608,"tmdb_type":"tv","type":"tv_series"},{"id":3108582,"title":"Sliders","year":1995,"imdb_id":"tt0112167","tmdb_id":1649,"tmdb_type":"tv","type":"tv_series"},{"id":344115,"title":"Friday
-        Night Lights","year":2006,"imdb_id":"tt0758745","tmdb_id":4278,"tmdb_type":"tv","type":"tv_series"},{"id":3103787,"title":"Saved
-        by the Bell","year":1989,"imdb_id":"tt0096694","tmdb_id":4345,"tmdb_type":"tv","type":"tv_series"},{"id":3173662,"title":"Young
-        Rock","year":2021,"imdb_id":"tt11639952","tmdb_id":97754,"tmdb_type":"tv","type":"tv_series"},{"id":37377,"title":"Ancient
-        Aliens","year":2009,"imdb_id":"tt1643266","tmdb_id":32608,"tmdb_type":"tv","type":"tv_series"},{"id":391773,"title":"Pawn
-        Stars","year":2009,"imdb_id":"tt1492088","tmdb_id":21755,"tmdb_type":"tv","type":"tv_series"},{"id":36912,"title":"American
+      string: '{"titles":[{"id":391773,"title":"Pawn Stars","year":2009,"imdb_id":"tt1492088","tmdb_id":21755,"tmdb_type":"tv","type":"tv_series"},{"id":36912,"title":"American
         Pickers","year":2010,"imdb_id":"tt1596786","tmdb_id":32025,"tmdb_type":"tv","type":"tv_series"},{"id":339144,"title":"Everybody
         Hates Chris","year":2005,"imdb_id":"tt0460637","tmdb_id":252,"tmdb_type":"tv","type":"tv_series"},{"id":3122711,"title":"The
         Game","year":2006,"imdb_id":"tt0772137","tmdb_id":211,"tmdb_type":"tv","type":"tv_series"},{"id":379569,"title":"Modern
@@ -1800,7 +1792,8 @@ http_interactions:
         Voice","year":2011,"imdb_id":"tt1839337","tmdb_id":37678,"tmdb_type":"tv","type":"tv_series"},{"id":3159626,"title":"The
         Titan Games","year":2019,"imdb_id":"tt7967262","tmdb_id":85487,"tmdb_type":"tv","type":"tv_series"},{"id":38150,"title":"Anthony
         Bourdain: No Reservations","year":2005,"imdb_id":"tt0475900","tmdb_id":4533,"tmdb_type":"tv","type":"tv_series"},{"id":3124678,"title":"The
-        Killer Speaks","year":2012,"imdb_id":"tt2860762","tmdb_id":46451,"tmdb_type":"tv","type":"tv_series"},{"id":3126337,"title":"The
+        Killer Speaks","year":2012,"imdb_id":"tt2860762","tmdb_id":46451,"tmdb_type":"tv","type":"tv_series"},{"id":3126311,"title":"The
+        Murder of Laci Peterson","year":2017,"imdb_id":"tt7293016","tmdb_id":73538,"tmdb_type":"tv","type":"tv_series"},{"id":3126337,"title":"The
         Musketeers","year":2014,"imdb_id":"tt2733252","tmdb_id":57736,"tmdb_type":"tv","type":"tv_series"},{"id":3108281,"title":"Skin
         Wars","year":2014,"imdb_id":"tt3231286","tmdb_id":62923,"tmdb_type":"tv","type":"tv_series"},{"id":358817,"title":"Iron
         Chef America","year":2004,"imdb_id":"tt0441718","tmdb_id":4360,"tmdb_type":"tv","type":"tv_series"},{"id":352645,"title":"Him
@@ -1813,7 +1806,7 @@ http_interactions:
         Place","year":1992,"imdb_id":"tt0103491","tmdb_id":4349,"tmdb_type":"tv","type":"tv_series"},{"id":3125478,"title":"The
         Lucy Show","year":1962,"imdb_id":"tt0055686","tmdb_id":2144,"tmdb_type":"tv","type":"tv_series"},{"id":323712,"title":"Cold
         Case Files","year":1999,"imdb_id":"tt0426666","tmdb_id":12258,"tmdb_type":"tv","type":"tv_series"},{"id":3147060,"title":"Yu-Gi-Oh!
-        GX","year":2004,"imdb_id":"tt0493334","tmdb_id":12536,"tmdb_type":"tv","type":"tv_series"},{"id":315082,"title":"Bleach","year":2004,"imdb_id":"tt0434665","tmdb_id":30984,"tmdb_type":"tv","type":"tv_series"},{"id":3114329,"title":"Survivorman","year":2004,"imdb_id":"tt0770659","tmdb_id":4437,"tmdb_type":"tv","type":"tv_series"},{"id":313664,"title":"Beverly
+        GX","year":2004,"imdb_id":"tt0493334","tmdb_id":12536,"tmdb_type":"tv","type":"tv_series"},{"id":3114329,"title":"Survivorman","year":2004,"imdb_id":"tt0770659","tmdb_id":4437,"tmdb_type":"tv","type":"tv_series"},{"id":313664,"title":"Beverly
         Hills, 90210","year":1990,"imdb_id":"tt0098749","tmdb_id":2025,"tmdb_type":"tv","type":"tv_series"},{"id":380684,"title":"Mountain
         Men","year":2012,"imdb_id":"tt2202488","tmdb_id":60381,"tmdb_type":"tv","type":"tv_series"},{"id":345639,"title":"Gangland
         Undercover","year":2015,"imdb_id":"tt4341996","tmdb_id":62172,"tmdb_type":"tv","type":"tv_series"},{"id":342435,"title":"Flashpoint","year":2008,"imdb_id":"tt1059475","tmdb_id":5829,"tmdb_type":"tv","type":"tv_series"},{"id":330526,"title":"Designing
@@ -1832,8 +1825,7 @@ http_interactions:
         After Time","year":2017,"imdb_id":"tt5031234","tmdb_id":68002,"tmdb_type":"tv","type":"tv_series"},{"id":358633,"title":"Intruders","year":2014,"imdb_id":"tt3552166","tmdb_id":61231,"tmdb_type":"tv","type":"tv_series"},{"id":39740,"title":"Atlantis","year":2013,"imdb_id":"tt2705602","tmdb_id":47054,"tmdb_type":"tv","type":"tv_series"},{"id":322947,"title":"Clarence","year":2013,"imdb_id":"tt3061050","tmdb_id":50035,"tmdb_type":"tv","type":"tv_series"},{"id":3112006,"title":"Steven
         Universe","year":2013,"imdb_id":"tt3061046","tmdb_id":61175,"tmdb_type":"tv","type":"tv_series"},{"id":3118708,"title":"The
         Amazing World of Gumball","year":2011,"imdb_id":"tt1942683","tmdb_id":37606,"tmdb_type":"tv","type":"tv_series"},{"id":34347,"title":"Adventure
-        Time: Islands","year":2010,"imdb_id":"tt1305826","tmdb_id":437217,"tmdb_type":"movie","type":"tv_series"},{"id":313105,"title":"Ben
-        10: Omniverse","year":2012,"imdb_id":"tt2293002","tmdb_id":46922,"tmdb_type":"tv","type":"tv_series"},{"id":399148,"title":"Regular
+        Time: Islands","year":2010,"imdb_id":"tt1305826","tmdb_id":437217,"tmdb_type":"movie","type":"tv_series"},{"id":399148,"title":"Regular
         Show","year":2009,"imdb_id":"tt1710308","tmdb_id":31132,"tmdb_type":"tv","type":"tv_series"},{"id":3112243,"title":"Storage
         Wars","year":2010,"imdb_id":"tt1785123","tmdb_id":34971,"tmdb_type":"tv","type":"tv_series"},{"id":317197,"title":"Broad
         City","year":2014,"imdb_id":"tt2578560","tmdb_id":60839,"tmdb_type":"tv","type":"tv_series"},{"id":363436,"title":"Key
@@ -1848,25 +1840,24 @@ http_interactions:
         Clover","year":2017,"imdb_id":"tt7441658","tmdb_id":73223,"tmdb_type":"tv","type":"tv_series"},{"id":340247,"title":"Fairy
         Tail","year":2009,"imdb_id":"tt1528406","tmdb_id":46261,"tmdb_type":"tv","type":"tv_series"},{"id":368167,"title":"Last
         Exile","year":2003,"imdb_id":"tt0390733","tmdb_id":31679,"tmdb_type":"tv","type":"tv_series"},{"id":3163042,"title":"Wise
-        Man\u2019s Grandchild","year":2019,"imdb_id":"tt9828724","tmdb_id":85844,"tmdb_type":"tv","type":"tv_series"},{"id":3106554,"title":"Shiki","year":2010,"imdb_id":"tt2016670","tmdb_id":36581,"tmdb_type":"tv","type":"tv_series"},{"id":380048,"title":"Monster
+        Man\u2019s Grandchild","year":2019,"imdb_id":"tt9828724","tmdb_id":85844,"tmdb_type":"tv","type":"tv_series"},{"id":380048,"title":"Monster
         Musume: Everyday Life with Monster Girls","year":2015,"imdb_id":"tt4831392","tmdb_id":63187,"tmdb_type":"tv","type":"tv_series"},{"id":39812,"title":"Attack
         on Titan","year":2013,"imdb_id":"tt2560140","tmdb_id":1429,"tmdb_type":"tv","type":"tv_series"},{"id":328079,"title":"Darker
         than Black","year":2007,"imdb_id":"tt0995941","tmdb_id":31718,"tmdb_type":"tv","type":"tv_series"},{"id":328357,"title":"Date
-        a Live","year":2013,"imdb_id":"tt2575684","tmdb_id":46004,"tmdb_type":"tv","type":"tv_series"},{"id":3160999,"title":"Kaguya-sama:
+        a Live","year":2013,"imdb_id":"tt2575684","tmdb_id":46004,"tmdb_type":"tv","type":"tv_series"},{"id":315082,"title":"Bleach","year":2004,"imdb_id":"tt0434665","tmdb_id":30984,"tmdb_type":"tv","type":"tv_series"},{"id":3160999,"title":"Kaguya-sama:
         Love is War","year":2019,"imdb_id":"tt9522300","tmdb_id":83121,"tmdb_type":"tv","type":"tv_series"},{"id":347014,"title":"Gintama","year":2005,"imdb_id":"tt0988818","tmdb_id":57041,"tmdb_type":"tv","type":"tv_series"},{"id":316174,"title":"Boruto:
         Naruto Next Generations","year":2017,"imdb_id":"tt6342474","tmdb_id":70881,"tmdb_type":"tv","type":"tv_series"},{"id":31763,"title":"60
         Days In","year":2016,"imdb_id":"tt5564124","tmdb_id":65854,"tmdb_type":"tv","type":"tv_series"},{"id":334608,"title":"Duck
         Dynasty","year":2012,"imdb_id":"tt2229907","tmdb_id":42738,"tmdb_type":"tv","type":"tv_series"},{"id":385284,"title":"Nightwatch","year":2015,"imdb_id":"tt4287464","tmdb_id":64559,"tmdb_type":"tv","type":"tv_series"},{"id":353159,"title":"Hoarders","year":2009,"imdb_id":"tt1497563","tmdb_id":30946,"tmdb_type":"tv","type":"tv_series"},{"id":3165367,"title":"Junjou
         Romantica","year":2008,"imdb_id":"tt1210339","tmdb_id":37548,"tmdb_type":"tv","type":"tv_series"},{"id":3166975,"title":"Digimon
-        Adventure:","year":2020,"imdb_id":"tt11645760","tmdb_id":98034,"tmdb_type":"tv","type":"tv_series"},{"id":3170934,"title":"Dragon
-        Quest: The Adventure of Dai","year":2020,"imdb_id":"tt11858104","tmdb_id":96884,"tmdb_type":"tv","type":"tv_series"},{"id":358654,"title":"InuYasha","year":2000,"imdb_id":"tt0290223","tmdb_id":35610,"tmdb_type":"tv","type":"tv_series"},{"id":3111877,"title":"Steins;Gate","year":2011,"imdb_id":"tt1910272","tmdb_id":42509,"tmdb_type":"tv","type":"tv_series"},{"id":381481,"title":"Mushi-Shi","year":2005,"imdb_id":"tt0807832","tmdb_id":26867,"tmdb_type":"tv","type":"tv_series"},{"id":360647,"title":"JoJo''s
-        Bizarre Adventure","year":2012,"imdb_id":"tt2359704","tmdb_id":45790,"tmdb_type":"tv","type":"tv_series"},{"id":371663,"title":"Log
+        Adventure:","year":2020,"imdb_id":"tt11645760","tmdb_id":98034,"tmdb_type":"tv","type":"tv_series"},{"id":358654,"title":"InuYasha","year":2000,"imdb_id":"tt0290223","tmdb_id":35610,"tmdb_type":"tv","type":"tv_series"},{"id":3111877,"title":"Steins;Gate","year":2011,"imdb_id":"tt1910272","tmdb_id":42509,"tmdb_type":"tv","type":"tv_series"},{"id":381481,"title":"Mushi-Shi","year":2005,"imdb_id":"tt0807832","tmdb_id":26867,"tmdb_type":"tv","type":"tv_series"},{"id":371663,"title":"Log
         Horizon","year":2013,"imdb_id":"tt2942218","tmdb_id":60846,"tmdb_type":"tv","type":"tv_series"},{"id":3170985,"title":"Yashahime:
         Princess Half-Demon","year":2020,"imdb_id":"tt12287748","tmdb_id":103254,"tmdb_type":"tv","type":"tv_series"},{"id":3161137,"title":"The
         Promised Neverland","year":2019,"imdb_id":"tt8788458","tmdb_id":83097,"tmdb_type":"tv","type":"tv_series"},{"id":32173,"title":"A
         Certain Magical Index","year":2008,"imdb_id":"tt1308089","tmdb_id":30980,"tmdb_type":"tv","type":"tv_series"},{"id":3114754,"title":"Sword
         Art Online","year":2012,"imdb_id":"tt2250192","tmdb_id":45782,"tmdb_type":"tv","type":"tv_series"},{"id":3102021,"title":"Rurouni
-        Kenshin","year":1996,"imdb_id":"tt0182629","tmdb_id":28136,"tmdb_type":"tv","type":"tv_series"},{"id":344439,"title":"Fruits
+        Kenshin","year":1996,"imdb_id":"tt0182629","tmdb_id":28136,"tmdb_type":"tv","type":"tv_series"},{"id":360647,"title":"JoJo''s
+        Bizarre Adventure","year":2012,"imdb_id":"tt2359704","tmdb_id":45790,"tmdb_type":"tv","type":"tv_series"},{"id":344439,"title":"Fruits
         Basket","year":2001,"imdb_id":"tt0328738","tmdb_id":36941,"tmdb_type":"tv","type":"tv_series"},{"id":3117502,"title":"Gurren
         Lagann","year":2007,"imdb_id":"tt0948103","tmdb_id":21729,"tmdb_type":"tv","type":"tv_series"},{"id":3124212,"title":"The
         Irregular at Magic High School","year":2014,"imdb_id":"tt3874528","tmdb_id":60833,"tmdb_type":"tv","type":"tv_series"},{"id":3118970,"title":"The
@@ -1894,14 +1885,14 @@ http_interactions:
         Shipp\u016bden","year":2007,"imdb_id":"tt0988824","tmdb_id":31910,"tmdb_type":"tv","type":"tv_series"},{"id":3103841,"title":"Say
         \"I Love You.\"","year":2012,"imdb_id":"tt2309312","tmdb_id":52878,"tmdb_type":"tv","type":"tv_series"},{"id":350986,"title":"Haven''t
         You Heard? I''m Sakamoto","year":2016,"imdb_id":"tt5701624","tmdb_id":65944,"tmdb_type":"tv","type":"tv_series"},{"id":315419,"title":"Blue
-        Exorcist","year":2011,"imdb_id":"tt1799631","tmdb_id":38464,"tmdb_type":"tv","type":"tv_series"},{"id":3106263,"title":"Shark
-        Tank","year":2009,"imdb_id":"tt1442550","tmdb_id":30703,"tmdb_type":"tv","type":"tv_series"},{"id":314933,"title":"black-ish","year":2014,"imdb_id":"tt3487356","tmdb_id":61381,"tmdb_type":"tv","type":"tv_series"},{"id":32584,"title":"A
+        Exorcist","year":2011,"imdb_id":"tt1799631","tmdb_id":38464,"tmdb_type":"tv","type":"tv_series"},{"id":314933,"title":"black-ish","year":2014,"imdb_id":"tt3487356","tmdb_id":61381,"tmdb_type":"tv","type":"tv_series"},{"id":32584,"title":"A
         Million Little Things","year":2018,"imdb_id":"tt7608248","tmdb_id":81499,"tmdb_type":"tv","type":"tv_series"},{"id":3123040,"title":"The
-        Good Doctor","year":2017,"imdb_id":"tt6470478","tmdb_id":71712,"tmdb_type":"tv","type":"tv_series"},{"id":3168100,"title":"Big
-        Sky","year":2020,"imdb_id":"tt11794642","tmdb_id":100010,"tmdb_type":"tv","type":"tv_series"},{"id":360558,"title":"Jimmy
+        Good Doctor","year":2017,"imdb_id":"tt6470478","tmdb_id":71712,"tmdb_type":"tv","type":"tv_series"},{"id":3106263,"title":"Shark
+        Tank","year":2009,"imdb_id":"tt1442550","tmdb_id":30703,"tmdb_type":"tv","type":"tv_series"},{"id":360558,"title":"Jimmy
         Kimmel Live!","year":2003,"imdb_id":"tt0320037","tmdb_id":1489,"tmdb_type":"tv","type":"tv_series"},{"id":3164102,"title":"For
         Life","year":2020,"imdb_id":"tt10327830","tmdb_id":92053,"tmdb_type":"tv","type":"tv_series"},{"id":332263,"title":"Dirty
-        Sexy Money","year":2007,"imdb_id":"tt0960136","tmdb_id":4053,"tmdb_type":"tv","type":"tv_series"},{"id":317400,"title":"Brothers
+        Sexy Money","year":2007,"imdb_id":"tt0960136","tmdb_id":4053,"tmdb_type":"tv","type":"tv_series"},{"id":3168100,"title":"Big
+        Sky","year":2020,"imdb_id":"tt11794642","tmdb_id":100010,"tmdb_type":"tv","type":"tv_series"},{"id":317400,"title":"Brothers
         and Sisters","year":2006,"imdb_id":"tt0758737","tmdb_id":341,"tmdb_type":"tv","type":"tv_series"},{"id":3136802,"title":"Ugly
         Betty","year":2006,"imdb_id":"tt0805669","tmdb_id":4626,"tmdb_type":"tv","type":"tv_series"},{"id":347786,"title":"Gold
         Rush","year":2010,"imdb_id":"tt1800864","tmdb_id":34634,"tmdb_type":"tv","type":"tv_series"},{"id":331861,"title":"Diesel
@@ -1971,6 +1962,6 @@ http_interactions:
         Treasure","year":2016,"imdb_id":"tt5571524","tmdb_id":67716,"tmdb_type":"tv","type":"tv_miniseries"},{"id":57950,"title":"Hellsing
         Ultimate","year":2006,"imdb_id":"tt0495212","tmdb_id":61752,"tmdb_type":"tv","type":"tv_miniseries"},{"id":540894,"title":"Dr.
         Seuss'' The Grinch Musical","year":2020,"imdb_id":"tt13437728","tmdb_id":762951,"tmdb_type":"movie","type":"tv_movie"},{"id":518964,"title":"The
-        Fades","year":2011,"imdb_id":"tt1772379","tmdb_id":41211,"tmdb_type":"tv","type":"tv_miniseries"},{"id":56244,"title":"FLCL","year":2000,"imdb_id":"tt0279077","tmdb_id":5895,"tmdb_type":"tv","type":"tv_miniseries"}],"page":8,"total_results":1994,"total_pages":8}'
-  recorded_at: Fri, 07 May 2021 03:02:08 GMT
+        Fades","year":2011,"imdb_id":"tt1772379","tmdb_id":41211,"tmdb_type":"tv","type":"tv_miniseries"},{"id":56244,"title":"FLCL","year":2000,"imdb_id":"tt0279077","tmdb_id":5895,"tmdb_type":"tv","type":"tv_miniseries"}],"page":8,"total_results":1980,"total_pages":8}'
+  recorded_at: Sat, 08 May 2021 23:04:43 GMT
 recorded_with: VCR 6.0.0

--- a/spec/models/movie_spec.rb
+++ b/spec/models/movie_spec.rb
@@ -246,9 +246,9 @@ describe Movie, type: :model do
         rating: 0
       )
 
-      expect(Movie.group_right_swiped(fantastic_four.id)).to eq([austin_powers])
-      expect(Movie.group_right_swiped(x_men.id)).to eq([austin_powers, nightcrawler])
-      expect(Movie.group_right_swiped(avengers.id)).to eq([austin_powers, theory_of_everything])
+      expect(Movie.group_matches(fantastic_four.id)).to eq([austin_powers])
+      expect(Movie.group_matches(x_men.id)).to eq([austin_powers, nightcrawler])
+      expect(Movie.group_matches(avengers.id)).to eq([austin_powers, theory_of_everything])
     end
   end
 end

--- a/spec/models/movie_spec.rb
+++ b/spec/models/movie_spec.rb
@@ -235,16 +235,6 @@ describe Movie, type: :model do
         user: ron,
         rating: 1
       )
-      Swipe.create(
-        movie: theory_of_everything,
-        user: nick,
-        rating: 0
-      )
-      Swipe.create(
-        movie: theory_of_everything,
-        user: tom,
-        rating: 0
-      )
 
       expect(Movie.group_matches(fantastic_four.id)).to eq([austin_powers])
       expect(Movie.group_matches(x_men.id)).to eq([austin_powers, nightcrawler])

--- a/spec/models/movie_spec.rb
+++ b/spec/models/movie_spec.rb
@@ -95,5 +95,160 @@ describe Movie, type: :model do
         expect(valid_movies).to include(movie)
       end
     end
+
+    it '.group_right_swiped' do
+      austin_powers = Movie.create(
+        title: 'Austin Powers: International Man of Mystery',
+        tmdb_id: 816
+      )
+      nightcrawler = Movie.create(
+        title: 'Nightcrawler',
+        tmdb_id: 242582
+      )
+      theory_of_everything = Movie.create(
+        title: 'The Theory of Everything',
+        tmdb_id: 266856
+      )
+
+      nick = User.create(
+        uid: '12345678910',
+        email: 'nick@example.com',
+        first_name: 'Nick',
+        last_name: 'King',
+        image: 'https://lh6.googleusercontent.com/-hEH5aK9fmMI/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucntLnugtaOVsqmvJGm89fFbDJ6GaQ/s96-c/photo.jpg'
+      )
+      ron = User.create(
+        uid: '12345678910',
+        email: 'ron@example.com',
+        first_name: 'Ron',
+        last_name: 'Swanson',
+        image: 'https://lh6.googleusercontent.com/-hEH5aK9fmMI/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucntLnugtaOVsqmvJGm89fFbDJ6GaQ/s96-c/photo.jpg'
+      )
+      tom = User.create(
+        uid: '12345678910',
+        email: 'tom@example.com',
+        first_name: 'Tom',
+        last_name: 'Haverford',
+        image: 'https://lh6.googleusercontent.com/-hEH5aK9fmMI/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucntLnugtaOVsqmvJGm89fFbDJ6GaQ/s96-c/photo.jpg'
+      )
+      leslie = User.create(
+        uid: '12345678910',
+        email: 'leslie@example.com',
+        first_name: 'Leslie',
+        last_name: 'Knope',
+        image: 'https://lh6.googleusercontent.com/-hEH5aK9fmMI/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucntLnugtaOVsqmvJGm89fFbDJ6GaQ/s96-c/photo.jpg'
+      )
+
+      fantastic_four = Group.create(
+        name: 'Fantastic Four'
+      )
+      avengers = Group.create(
+        name: 'The Avengers'
+      )
+      x_men = Group.create(
+        name: 'X Men'
+      )
+      UserGroup.create(
+        user: nick,
+        group: fantastic_four
+      )
+      UserGroup.create(
+        user: ron,
+        group: fantastic_four
+      )
+      UserGroup.create(
+        user: tom,
+        group: fantastic_four
+      )
+      UserGroup.create(
+        user: leslie,
+        group: fantastic_four
+      )
+      UserGroup.create(
+        user: nick,
+        group: x_men
+      )
+      UserGroup.create(
+        user: ron,
+        group: x_men
+      )
+      UserGroup.create(
+        user: tom,
+        group: x_men
+      )
+      UserGroup.create(
+        user: ron,
+        group: avengers
+      )
+      UserGroup.create(
+        user: leslie,
+        group: avengers
+      )
+
+      Swipe.create(
+        movie: austin_powers,
+        user: nick,
+        rating: 1
+      )
+      Swipe.create(
+        movie: austin_powers,
+        user: ron,
+        rating: 1
+      )
+      Swipe.create(
+        movie: austin_powers,
+        user: tom,
+        rating: 1
+      )
+      Swipe.create(
+        movie: austin_powers,
+        user: leslie,
+        rating: 1
+      )
+      Swipe.create(
+        movie: nightcrawler,
+        user: nick,
+        rating: 1
+      )
+      Swipe.create(
+        movie: nightcrawler,
+        user: ron,
+        rating: 1
+      )
+      Swipe.create(
+        movie: nightcrawler,
+        user: tom,
+        rating: 1
+      )
+      Swipe.create(
+        movie: nightcrawler,
+        user: leslie,
+        rating: 0
+      )
+      Swipe.create(
+        movie: theory_of_everything,
+        user: leslie,
+        rating: 1
+      )
+      Swipe.create(
+        movie: theory_of_everything,
+        user: ron,
+        rating: 1
+      )
+      Swipe.create(
+        movie: theory_of_everything,
+        user: nick,
+        rating: 0
+      )
+      Swipe.create(
+        movie: theory_of_everything,
+        user: tom,
+        rating: 0
+      )
+
+      expect(Movie.group_right_swiped(fantastic_four.id)).to eq([austin_powers])
+      expect(Movie.group_right_swiped(x_men.id)).to eq([austin_powers, nightcrawler])
+      expect(Movie.group_right_swiped(avengers.id)).to eq([austin_powers, theory_of_everything])
+    end
   end
 end

--- a/spec/requests/api/v1/groups_request_spec.rb
+++ b/spec/requests/api/v1/groups_request_spec.rb
@@ -293,13 +293,13 @@ describe 'Groups API' do
     )
     netflix = Service.create(
       name: 'Netflix',
-      watchmode_id: 1234,
-      logo: 'netflix.jpeg'
+      watchmode_id: 203,
+      logo: 'netflix_logo.png'
     )
     hulu = Service.create(
       name: 'Hulu',
       watchmode_id: 157,
-      logo: 'hulu_logo.png'
+      logo: 'hulu_logo.jpeg'
     )
     MovieAvailability.create(
       movie: austin_powers,

--- a/spec/requests/api/v1/groups_request_spec.rb
+++ b/spec/requests/api/v1/groups_request_spec.rb
@@ -269,6 +269,28 @@ describe 'Groups API' do
     x_men = Group.create(
       name: 'X Men'
     )
+    netflix = Service.create(
+      name: 'Netflix',
+      watchmode_id: 1234,
+      logo: 'netflix.jpeg'
+    )
+    hulu = Service.create(
+      name: 'Hulu',
+      watchmode_id: 157,
+      logo: 'hulu_logo.png'
+    )
+    MovieAvailability.create(
+      movie: austin_powers,
+      service: netflix
+    )
+    MovieAvailability.create(
+      movie: austin_powers,
+      service: hulu
+    )
+    MovieAvailability.create(
+      movie: nightcrawler,
+      service: netflix
+    )
     UserGroup.create(
       user: nick,
       group: x_men
@@ -324,16 +346,17 @@ describe 'Groups API' do
 
     get "/api/v1/groups/#{x_men.id}/matches"
     json = JSON.parse(response.body, symbolize_names:true)
-
+# binding.pry
     expect(response).to be_successful
     expect(json).to be_a(Hash)
     expect(json).to have_key(:data)
     expect(json[:data]).to be_an(Array)
     expect(json[:data].length).to eq(2)
+    expect(json[:data][0]).to be_a(Hash)
     expect(json[:data][0]).to have_key(:id)
     expect(json[:data][0][:id]).to eq(austin_powers.id.to_s)
     expect(json[:data][0]).to have_key(:type)
-    expect(json[:data][0][:type]).to eq('movie')
+    expect(json[:data][0][:type]).to eq('match')
     expect(json[:data][0]).to have_key(:attributes)
     expect(json[:data][0][:attributes]).to be_a(Hash)
     expect(json[:data][0][:attributes]).to have_key(:title)
@@ -352,10 +375,41 @@ describe 'Groups API' do
     expect(json[:data][0][:attributes][:vote_average]).to eq(austin_powers.vote_average)
     expect(json[:data][0][:attributes]).to have_key(:year)
     expect(json[:data][0][:attributes][:year]).to eq(austin_powers.year)
+    expect(json[:data][0][:attributes]).to have_key(:services)
+    expect(json[:data][0][:attributes][:services]).to be_an(Array)
+    expect(json[:data][0][:attributes][:services].length).to eq(2)
+    expect(json[:data][0][:attributes][:services][0]).to be_a(Hash)
+    expect(json[:data][0][:attributes][:services][0]).to have_key(:id)
+    expect(json[:data][0][:attributes][:services][0][:id]).to eq(netflix.id)
+    expect(json[:data][0][:attributes][:services][0]).to have_key(:name)
+    expect(json[:data][0][:attributes][:services][0][:name]).to eq(netflix.name)
+    expect(json[:data][0][:attributes][:services][0]).to have_key(:watchmode_id)
+    expect(json[:data][0][:attributes][:services][0][:watchmode_id]).to eq(netflix.watchmode_id)
+    expect(json[:data][0][:attributes][:services][0]).to have_key(:created_at)
+    expect(json[:data][0][:attributes][:services][0][:created_at]).to be_a(String)
+    expect(json[:data][0][:attributes][:services][0]).to have_key(:updated_at)
+    expect(json[:data][0][:attributes][:services][0][:updated_at]).to be_a(String)
+    expect(json[:data][0][:attributes][:services][0]).to have_key(:logo)
+    expect(json[:data][0][:attributes][:services][0][:logo]).to eq(netflix.logo)
+    expect(json[:data][0][:attributes][:services][1]).to be_a(Hash)
+    expect(json[:data][0][:attributes][:services][1]).to have_key(:id)
+    expect(json[:data][0][:attributes][:services][1][:id]).to eq(hulu.id)
+    expect(json[:data][0][:attributes][:services][1]).to have_key(:name)
+    expect(json[:data][0][:attributes][:services][1][:name]).to eq(hulu.name)
+    expect(json[:data][0][:attributes][:services][1]).to have_key(:watchmode_id)
+    expect(json[:data][0][:attributes][:services][1][:watchmode_id]).to eq(hulu.watchmode_id)
+    expect(json[:data][0][:attributes][:services][1]).to have_key(:created_at)
+    expect(json[:data][0][:attributes][:services][1][:created_at]).to be_a(String)
+    expect(json[:data][0][:attributes][:services][1]).to have_key(:updated_at)
+    expect(json[:data][0][:attributes][:services][1][:updated_at]).to be_a(String)
+    expect(json[:data][0][:attributes][:services][1]).to have_key(:logo)
+    expect(json[:data][0][:attributes][:services][1][:logo]).to eq(hulu.logo)
+
+    expect(json[:data][1]).to be_a(Hash)
     expect(json[:data][1]).to have_key(:id)
     expect(json[:data][1][:id]).to eq(nightcrawler.id.to_s)
     expect(json[:data][1]).to have_key(:type)
-    expect(json[:data][1][:type]).to eq('movie')
+    expect(json[:data][1][:type]).to eq('match')
     expect(json[:data][1]).to have_key(:attributes)
     expect(json[:data][1][:attributes]).to be_a(Hash)
     expect(json[:data][1][:attributes]).to have_key(:title)
@@ -374,5 +428,20 @@ describe 'Groups API' do
     expect(json[:data][1][:attributes][:vote_average]).to eq(nightcrawler.vote_average)
     expect(json[:data][1][:attributes]).to have_key(:year)
     expect(json[:data][1][:attributes][:year]).to eq(nightcrawler.year)
+    expect(json[:data][1][:attributes][:services]).to be_an(Array)
+    expect(json[:data][1][:attributes][:services].length).to eq(1)
+    expect(json[:data][1][:attributes][:services][0]).to be_a(Hash)
+    expect(json[:data][1][:attributes][:services][0]).to have_key(:id)
+    expect(json[:data][1][:attributes][:services][0][:id]).to eq(netflix.id)
+    expect(json[:data][1][:attributes][:services][0]).to have_key(:name)
+    expect(json[:data][1][:attributes][:services][0][:name]).to eq(netflix.name)
+    expect(json[:data][1][:attributes][:services][0]).to have_key(:watchmode_id)
+    expect(json[:data][1][:attributes][:services][0][:watchmode_id]).to eq(netflix.watchmode_id)
+    expect(json[:data][1][:attributes][:services][0]).to have_key(:created_at)
+    expect(json[:data][1][:attributes][:services][0][:created_at]).to be_a(String)
+    expect(json[:data][1][:attributes][:services][0]).to have_key(:updated_at)
+    expect(json[:data][1][:attributes][:services][0][:updated_at]).to be_a(String)
+    expect(json[:data][1][:attributes][:services][0]).to have_key(:logo)
+    expect(json[:data][1][:attributes][:services][0][:logo]).to eq(netflix.logo)
   end
 end

--- a/spec/requests/api/v1/groups_request_spec.rb
+++ b/spec/requests/api/v1/groups_request_spec.rb
@@ -256,11 +256,28 @@ describe 'Groups API' do
     )
     austin_powers = Movie.create(
       title: 'Austin Powers: International Man of Mystery',
-      tmdb_id: 816
+      tmdb_id: 816,
+      poster_path: '/1PkGnyFwRyapmbuILIOXXxiSh7Y.jpg',
+      description: "As a swingin' fashion photographer by day and a groovy British superagent by night, Austin Powers is the '60s' most shagadelic spy, baby! But can he stop megalomaniac Dr. Evil after the bald villain freezes himself and unthaws in the '90s? With the help of sexy sidekick Vanessa Kensington, he just might.",
+      vote_average: 6.5,
+      vote_count: 2349,
+      year: '1997'
+    )
+    comedy = austin_powers.genres.create(
+      name: 'Comedy',
+      tmdb_id: 14
+    )
+    action = austin_powers.genres.create(
+      name: 'Action',
+      tmdb_id: 16
     )
     nightcrawler = Movie.create(
       title: 'Nightcrawler',
       tmdb_id: 242582
+    )
+    thriller = nightcrawler.genres.create(
+      name: 'Thriller',
+      tmdb_id: 11
     )
     theory_of_everything = Movie.create(
       title: 'The Theory of Everything',
@@ -346,7 +363,7 @@ describe 'Groups API' do
 
     get "/api/v1/groups/#{x_men.id}/matches"
     json = JSON.parse(response.body, symbolize_names:true)
-# binding.pry
+
     expect(response).to be_successful
     expect(json).to be_a(Hash)
     expect(json).to have_key(:data)
@@ -368,7 +385,26 @@ describe 'Groups API' do
     expect(json[:data][0][:attributes]).to have_key(:description)
     expect(json[:data][0][:attributes][:description]).to eq(austin_powers.description)
     expect(json[:data][0][:attributes]).to have_key(:genres)
-    expect(json[:data][0][:attributes][:genres]).to eq(austin_powers.genres)
+    expect(json[:data][0][:attributes][:genres]).to be_an(Array)
+    expect(json[:data][0][:attributes][:genres].length).to eq(2)
+    expect(json[:data][0][:attributes][:genres][0]).to be_a(Hash)
+    expect(json[:data][0][:attributes][:genres][0]).to have_key(:id)
+    expect(json[:data][0][:attributes][:genres][0][:id]).to eq(comedy.id)
+    expect(json[:data][0][:attributes][:genres][0]).to have_key(:created_at)
+    expect(json[:data][0][:attributes][:genres][0][:created_at]).to be_a(String)
+    expect(json[:data][0][:attributes][:genres][0]).to have_key(:updated_at)
+    expect(json[:data][0][:attributes][:genres][0][:updated_at]).to be_a(String)
+    expect(json[:data][0][:attributes][:genres][0]).to have_key(:tmdb_id)
+    expect(json[:data][0][:attributes][:genres][0][:tmdb_id]).to eq(comedy.tmdb_id)
+    expect(json[:data][0][:attributes][:genres][1]).to be_a(Hash)
+    expect(json[:data][0][:attributes][:genres][1]).to have_key(:id)
+    expect(json[:data][0][:attributes][:genres][1][:id]).to eq(action.id)
+    expect(json[:data][0][:attributes][:genres][1]).to have_key(:created_at)
+    expect(json[:data][0][:attributes][:genres][1][:created_at]).to be_a(String)
+    expect(json[:data][0][:attributes][:genres][1]).to have_key(:updated_at)
+    expect(json[:data][0][:attributes][:genres][1][:updated_at]).to be_a(String)
+    expect(json[:data][0][:attributes][:genres][1]).to have_key(:tmdb_id)
+    expect(json[:data][0][:attributes][:genres][1][:tmdb_id]).to eq(action.tmdb_id)
     expect(json[:data][0][:attributes]).to have_key(:vote_count)
     expect(json[:data][0][:attributes][:vote_count]).to eq(austin_powers.vote_count)
     expect(json[:data][0][:attributes]).to have_key(:vote_average)
@@ -421,7 +457,17 @@ describe 'Groups API' do
     expect(json[:data][1][:attributes]).to have_key(:description)
     expect(json[:data][1][:attributes][:description]).to eq(nightcrawler.description)
     expect(json[:data][1][:attributes]).to have_key(:genres)
-    expect(json[:data][1][:attributes][:genres]).to eq(nightcrawler.genres)
+    expect(json[:data][1][:attributes][:genres]).to be_an(Array)
+    expect(json[:data][1][:attributes][:genres].length).to eq(1)
+    expect(json[:data][1][:attributes][:genres][0]).to be_a(Hash)
+    expect(json[:data][1][:attributes][:genres][0]).to have_key(:id)
+    expect(json[:data][1][:attributes][:genres][0][:id]).to eq(thriller.id)
+    expect(json[:data][1][:attributes][:genres][0]).to have_key(:created_at)
+    expect(json[:data][1][:attributes][:genres][0][:created_at]).to be_a(String)
+    expect(json[:data][1][:attributes][:genres][0]).to have_key(:updated_at)
+    expect(json[:data][1][:attributes][:genres][0][:updated_at]).to be_a(String)
+    expect(json[:data][1][:attributes][:genres][0]).to have_key(:tmdb_id)
+    expect(json[:data][1][:attributes][:genres][0][:tmdb_id]).to eq(thriller.tmdb_id)
     expect(json[:data][1][:attributes]).to have_key(:vote_count)
     expect(json[:data][1][:attributes][:vote_count]).to eq(nightcrawler.vote_count)
     expect(json[:data][1][:attributes]).to have_key(:vote_average)

--- a/spec/requests/api/v1/groups_request_spec.rb
+++ b/spec/requests/api/v1/groups_request_spec.rb
@@ -273,7 +273,12 @@ describe 'Groups API' do
     )
     nightcrawler = Movie.create(
       title: 'Nightcrawler',
-      tmdb_id: 242582
+      tmdb_id: 242582,
+      poster_path: '/j9HrX8f7GbZQm1BrBiR40uFQZSb.jpg',
+      description: 'When Lou Bloom, desperate for work, muscles into the world of L.A. crime journalism, he blurs the line between observer and participant to become the star of his own story. Aiding him in his effort is Nina, a TV-news veteran.',
+      vote_average: 7.7,
+      vote_count: 8018,
+      year: '2014'
     )
     thriller = nightcrawler.genres.create(
       name: 'Thriller',

--- a/spec/requests/api/v1/groups_request_spec.rb
+++ b/spec/requests/api/v1/groups_request_spec.rb
@@ -231,4 +231,148 @@ describe 'Groups API' do
     expect(json[:data][:attributes][:users][1]).to have_key(:updated_at)
     expect(json[:data][:attributes][:users][1][:updated_at]).to be_a(String)
   end
+
+  it 'can retreive all movie matches for a group' do
+    nick = User.create(
+      uid: '12345678910',
+      email: 'nick@example.com',
+      first_name: 'Nick',
+      last_name: 'King',
+      image: 'https://lh6.googleusercontent.com/-hEH5aK9fmMI/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucntLnugtaOVsqmvJGm89fFbDJ6GaQ/s96-c/photo.jpg'
+    )
+    ron = User.create(
+      uid: '12345678910',
+      email: 'ron@example.com',
+      first_name: 'Ron',
+      last_name: 'Swanson',
+      image: 'https://lh6.googleusercontent.com/-hEH5aK9fmMI/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucntLnugtaOVsqmvJGm89fFbDJ6GaQ/s96-c/photo.jpg'
+    )
+    tom = User.create(
+      uid: '12345678910',
+      email: 'tom@example.com',
+      first_name: 'Tom',
+      last_name: 'Haverford',
+      image: 'https://lh6.googleusercontent.com/-hEH5aK9fmMI/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucntLnugtaOVsqmvJGm89fFbDJ6GaQ/s96-c/photo.jpg'
+    )
+    austin_powers = Movie.create(
+      title: 'Austin Powers: International Man of Mystery',
+      tmdb_id: 816
+    )
+    nightcrawler = Movie.create(
+      title: 'Nightcrawler',
+      tmdb_id: 242582
+    )
+    theory_of_everything = Movie.create(
+      title: 'The Theory of Everything',
+      tmdb_id: 266856
+    )
+    x_men = Group.create(
+      name: 'X Men'
+    )
+    UserGroup.create(
+      user: nick,
+      group: x_men
+    )
+    UserGroup.create(
+      user: ron,
+      group: x_men
+    )
+    UserGroup.create(
+      user: tom,
+      group: x_men
+    )
+    Swipe.create(
+      movie: austin_powers,
+      user: nick,
+      rating: 1
+    )
+    Swipe.create(
+      movie: austin_powers,
+      user: ron,
+      rating: 1
+    )
+    Swipe.create(
+      movie: austin_powers,
+      user: tom,
+      rating: 1
+    )
+    Swipe.create(
+      movie: nightcrawler,
+      user: nick,
+      rating: 1
+    )
+    Swipe.create(
+      movie: nightcrawler,
+      user: ron,
+      rating: 1
+    )
+    Swipe.create(
+      movie: nightcrawler,
+      user: tom,
+      rating: 1
+    )
+    Swipe.create(
+      movie: theory_of_everything,
+      user: nick,
+      rating: 1
+    )
+    Swipe.create(
+      movie: theory_of_everything,
+      user: ron,
+      rating: 0
+    )
+
+    get "/api/v1/groups/#{x_men.id}/matches"
+    json = JSON.parse(response.body, symbolize_names:true)
+
+    expect(response).to be_successful
+    expect(json).to be_a(Hash)
+    expect(json).to have_key(:data)
+    expect(json[:data]).to be_an(Array)
+    expect(json[:data].length).to eq(2)
+    expect(json[:data][0]).to have_key(:id)
+    expect(json[:data][0][:id]).to eq(austin_powers.id.to_s)
+    expect(json[:data][0]).to have_key(:type)
+    expect(json[:data][0][:type]).to eq('movie')
+    expect(json[:data][0]).to have_key(:attributes)
+    expect(json[:data][0][:attributes]).to be_a(Hash)
+    expect(json[:data][0][:attributes]).to have_key(:title)
+    expect(json[:data][0][:attributes][:title]).to eq(austin_powers.title)
+    expect(json[:data][0][:attributes]).to have_key(:tmdb_id)
+    expect(json[:data][0][:attributes][:tmdb_id]).to eq(austin_powers.tmdb_id)
+    expect(json[:data][0][:attributes]).to have_key(:poster_path)
+    expect(json[:data][0][:attributes][:poster_path]).to eq(austin_powers.poster_path)
+    expect(json[:data][0][:attributes]).to have_key(:description)
+    expect(json[:data][0][:attributes][:description]).to eq(austin_powers.description)
+    expect(json[:data][0][:attributes]).to have_key(:genres)
+    expect(json[:data][0][:attributes][:genres]).to eq(austin_powers.genres)
+    expect(json[:data][0][:attributes]).to have_key(:vote_count)
+    expect(json[:data][0][:attributes][:vote_count]).to eq(austin_powers.vote_count)
+    expect(json[:data][0][:attributes]).to have_key(:vote_average)
+    expect(json[:data][0][:attributes][:vote_average]).to eq(austin_powers.vote_average)
+    expect(json[:data][0][:attributes]).to have_key(:year)
+    expect(json[:data][0][:attributes][:year]).to eq(austin_powers.year)
+    expect(json[:data][1]).to have_key(:id)
+    expect(json[:data][1][:id]).to eq(nightcrawler.id.to_s)
+    expect(json[:data][1]).to have_key(:type)
+    expect(json[:data][1][:type]).to eq('movie')
+    expect(json[:data][1]).to have_key(:attributes)
+    expect(json[:data][1][:attributes]).to be_a(Hash)
+    expect(json[:data][1][:attributes]).to have_key(:title)
+    expect(json[:data][1][:attributes][:title]).to eq(nightcrawler.title)
+    expect(json[:data][1][:attributes]).to have_key(:tmdb_id)
+    expect(json[:data][1][:attributes][:tmdb_id]).to eq(nightcrawler.tmdb_id)
+    expect(json[:data][1][:attributes]).to have_key(:poster_path)
+    expect(json[:data][1][:attributes][:poster_path]).to eq(nightcrawler.poster_path)
+    expect(json[:data][1][:attributes]).to have_key(:description)
+    expect(json[:data][1][:attributes][:description]).to eq(nightcrawler.description)
+    expect(json[:data][1][:attributes]).to have_key(:genres)
+    expect(json[:data][1][:attributes][:genres]).to eq(nightcrawler.genres)
+    expect(json[:data][1][:attributes]).to have_key(:vote_count)
+    expect(json[:data][1][:attributes][:vote_count]).to eq(nightcrawler.vote_count)
+    expect(json[:data][1][:attributes]).to have_key(:vote_average)
+    expect(json[:data][1][:attributes][:vote_average]).to eq(nightcrawler.vote_average)
+    expect(json[:data][1][:attributes]).to have_key(:year)
+    expect(json[:data][1][:attributes][:year]).to eq(nightcrawler.year)
+  end
 end


### PR DESCRIPTION
This PR will:
* Create tests and functionality for GET '/groups/:id/matches' endpoint - returns movies that all users of a group have swiped right on including genre and service information

- [x] Fully tested
- [x] Issues created: Adapt Movie model method .group_matches to use ActiveRecord
