### PR TITLE
Fix Add Description Method

### DIFF
--- a/app/poros/movie_info.rb
+++ b/app/poros/movie_info.rb
@@ -24,8 +24,8 @@ class MovieInfo
   end
 
   def add_description(movie_data)
-    if movie_data[:description]
-      movie_data[:description]
+    if movie_data[:overview]
+      movie_data[:overview]
     else
       'No description available'
     end


### PR DESCRIPTION
This PR will:
* Fix a bug with add_description method that resulted in all movies having a no description message
